### PR TITLE
ex10: Add a workaround for stdout buffering mishandling

### DIFF
--- a/example10/conduit.c
+++ b/example10/conduit.c
@@ -61,6 +61,7 @@ static int conduit_send (flux_t *h, const char *json_str)
         flux_log_error (h, "send error %s", __FUNCTION__);
         return rc;
     }
+    flux_log (h, LOG_INFO, "conduit_send succeed");
     return 0;
 }
 

--- a/example10/conduit.c
+++ b/example10/conduit.c
@@ -75,7 +75,7 @@ static void conduit_put_request_cb (flux_t *h, flux_msg_handler_t *w,
 
     flux_log (h, LOG_INFO, "conduit_put_request_cb:");
     if (ctx->connected == false) {
-        flux_log (h, LOG_INFO, "conduit not connecte");
+        flux_log (h, LOG_INFO, "conduit not connected");
         errno = ENOTCONN;
         goto done;
     }

--- a/example10/datastore.py
+++ b/example10/datastore.py
@@ -28,7 +28,7 @@ def run ():
     global sock
     global store
     connection, client_address = sock.accept()
-    while True:
+    for x in range (5):
        print "Waiting for a packet"
        mybytes = bytearray (4)
        nbytes, address = connection.recvfrom_into (mybytes, 4)


### PR DESCRIPTION
This PR fixes a problem where stdout from a Python program does not make into kvs unless it exits. Along with that, I add a couple of commits to improve logging. 