### PR TITLE
doc: Updating README.md in example1

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,1 @@
+This is the README for the branch flux-core-0.11.flux-sched-0.7

--- a/example1/README.md
+++ b/example1/README.md
@@ -1,18 +1,25 @@
-### 1. Partitioning Schedule
+### Example 1(a) - Partitioning Schedule
 
-- Launch a flux instance and schedule/launch compute and io-forwarding jobs on separate nodes
+#### Description: Launch a flux instance and schedule/launch compute and io-forwarding jobs on separate nodes
 
-- **salloc -N3 -ppdebug**
+1. `salloc -N3 -ppdebug`
 
-- **setenv FLUX_SCHED_OPTIONS "node-excl=true"** *# Make sure the scheduler module will do node-exclusive scheduling*
+2. Make sure the scheduler module will do node-exclusive scheduling:
 
-- **srun --pty --mpi=none -N3 /usr/global/tools/flux/toss_3_x86_64_ib/default/bin/flux start -o,-S,log-filename=out**
+| Shell     | Command                                        |
+| -----     | ----------                                     |
+| tcsh      | `setenv FLUX_SCHED_OPTIONS "node-excl=true"`   |
+| bash/zsh  | `export FLUX_SCHED_OPTIONS='node-excl=true'`   |
 
-- **flux submit --nnodes=2 --ntasks=4 --cores-per-task=2 ./compute.lua 120**
+3. `srun --pty --mpi=none -N3 flux start -o,-S,log-filename=out`
 
-- **flux submit --nnodes=1 --ntasks=1 --cores-per-task=2 ./io-forwarding.lua 120**
+4. `flux submit --nnodes=2 --ntasks=4 --cores-per-task=2 ./compute.lua 120`
 
-- **flux wreck ls**
+5. `flux submit --nnodes=1 --ntasks=1 --cores-per-task=2 ./io-forwarding.lua 120`
+
+6. List jobs in KVS:
+
+`flux wreck ls`
 
 ```
     ID NTASKS STATE                    START      RUNTIME    RANKS COMMAND
@@ -20,34 +27,43 @@
      1      4 running    2018-05-11T14:58:33       9.284s    [0-1] compute.lua
 ```
 
-- **flux kvs get lwj.0.0.1.R_lite**
+7. Get value stored under job key:
+
+`flux kvs get lwj.0.0.1.R_lite`
 
 ```json
 [ { "node": "quartz32", "children": { "core": "0-3" }, "rank": 0 },
   { "node": "quartz33", "children": { "core": "0-3" }, "rank": 1 } ]
 ```
 
-- **flux kvs get lwj.0.0.2.R_lite**
+`flux kvs get lwj.0.0.2.R_lite`
 
 ```json
 [ { "node": "quartz34", "children": { "core": "0-1" }, "rank": 2 } ]
 ```
 
-### 2. Overlapping Schedule
+### Example 1(b) - Overlapping Schedule
 
-- Launch a flux instance and schedule/launch both compute and io-forwarding jobs across all nodes
+#### Description: Launch a flux instance and schedule/launch both compute and io-forwarding jobs across all nodes
 
-- **salloc -N3 -ppdebug**
+1. `salloc -N3 -ppdebug`
 
-- **unsetenv FLUX_SCHED_OPTIONS** *# Make sure the scheduler module will do core-level scheduling*
+2. Make sure the scheduler module will do core-level scheduling:
 
-- **srun --pty --mpi=none -N3 /g/g0/dahn/workspace/planner_correction/inst/bin/flux start -o,-S,log-filename=out**
+| Shell     | Command                       |
+| -----     | ----------                    |
+| tcsh      | `unsetenv FLUX_SCHED_OPTIONS` |
+| bash/zsh  | `unset FLUX_SCHED_OPTIONS`    |
 
-- **flux submit --nnodes=3 --ntasks=6 --cores-per-task=2 ./compute.lua 120**
+3. `srun --pty --mpi=none -N3 flux start -o,-S,log-filename=out`
 
-- **flux submit --nnodes=3 --ntasks=3 --cores-per-task=1 ./io-forwarding.lua 120**
+4. `flux submit --nnodes=3 --ntasks=6 --cores-per-task=2 ./compute.lua 120`
 
-- **flux wreck ls**
+5. `flux submit --nnodes=3 --ntasks=3 --cores-per-task=1 ./io-forwarding.lua 120`
+
+6. List jobs in KVS:
+
+`flux wreck ls`
 
 ```
     ID NTASKS STATE                    START      RUNTIME    RANKS COMMAND
@@ -55,7 +71,9 @@
      1      6 running    2018-05-11T15:09:23      17.956s    [0-2] compute.lua
 ```
 
-- **flux kvs get lwj.0.0.1.R_lite**
+7. Get value stored under job key:
+
+`flux kvs get lwj.0.0.1.R_lite`
 
 ```json
 [ { "node": "quartz32", "children": { "core": "0-3" }, "rank": 0 },
@@ -63,11 +81,10 @@
   { "node": "quartz34", "children": { "core": "0-3" }, "rank": 2 } ]
 ```
 
-- **flux kvs get lwj.0.0.2.R_lite**
+`flux kvs get lwj.0.0.2.R_lite`
 
 ```json
 [ { "node": "quartz32", "children": { "core": "4" }, "rank": 0 },
   { "node": "quartz33", "children": { "core": "4" }, "rank": 1 },
   { "node": "quartz34", "children": { "core": "4" }, "rank": 2 } ]
 ```
-


### PR DESCRIPTION
This PR makes changes to README.md to include the following formatting changes:

- A table listing of the equivalent commands for setting FLUX_SCHED_OPTIONS in both tcsh and bash/zsh shells.
- Numbers for each step in the sub-examples instead of bullet points.
- Markdown code format for the command line steps in each example instead of bold font.