### PR TITLE
doc: Updating README.md, submitter scripts in example2

### DIFF
--- a/example2/README.md
+++ b/example2/README.md
@@ -1,16 +1,23 @@
-### Using direct job.submit RPC
+### Example 2(a) - Using a direct job.submit RPC
 
-Schedule/launch compute and io-forwarding jobs on separate nodes
+#### Description: Schedule and launch compute and io-forwarding jobs on separate nodes
 
-- **salloc -N3 -ppdebug**
+1. `salloc -N3 -ppdebug`
 
-- **setenv FLUX_SCHED_OPTIONS "node-excl=true"** # Make sure the scheduler module will do node-exclusive scheduling 
+2. Make sure the scheduler module will do node-exclusive scheduling
 
-- **srun --pty --mpi=none -N3 /usr/global/tools/flux/toss_3_x86_64_ib/default/bin/flux start -o,-S,log-filename=out**
+| Shell     | Command                                        |
+| -----     | ----------                                     |
+| tcsh      | `setenv FLUX_SCHED_OPTIONS "node-excl=true"`   |
+| bash/zsh  | `export FLUX_SCHED_OPTIONS='node-excl=true'`   |
 
-- **./submitter.lua** # or ./submitter.py
+3. `srun --pty --mpi=none -N3 flux start -o,-S,log-filename=out`
 
-- **flux wreck ls**
+4. `./submitter.lua` or `./submitter.py`
+
+5. List jobs in KVS:
+
+`flux wreck ls`
 
 ```
     ID NTASKS STATE                    START      RUNTIME    RANKS COMMAND
@@ -18,32 +25,41 @@ Schedule/launch compute and io-forwarding jobs on separate nodes
      2      1 running    2018-05-11T17:41:56       0.105s        2 io-forwarding
 ```
 
-- **flux kvs get lwj.0.0.1.R_lite**
+7. Get value stored under job key:
+
+`flux kvs get lwj.0.0.1.R_lite`
 
 ```
 [ { "node": "quartz23", "children": { "core": "0-3" }, "rank": 0 },
   { "node": "quartz24", "children": { "core": "0-3" }, "rank": 1 } ]
 ```
 
-- **flux kvs get lwj.0.0.2.R_lite**
+`flux kvs get lwj.0.0.2.R_lite`
 
 ```
 [ { "node": "quartz25", "children": { "core": "0" }, "rank": 2 } ]
 ```
 
-### job.submit RPC example 2
+### Example 2(b) - Using a direct job.submit RPC
 
-Sschedule/launch both compute and io-forwarding jobs across all nodes
+#### Description: Schedule and launch both compute and io-forwarding jobs across all nodes
 
-- **salloc -N3 -ppdebug**
+1. `salloc -N3 -ppdebug`
 
-- **unsetenv FLUX_SCHED_OPTIONS** # Make sure the scheduler module will do core-level scheduling
+2. Make sure the scheduler module will do core-level scheduling:
 
-- **srun --pty --mpi=none -N3 /g/g0/dahn/workspace/planner_correction/inst/bin/flux start -o,-S,log-filename=out**
+| Shell     | Command                       |
+| -----     | ----------                    |
+| tcsh      | `unsetenv FLUX_SCHED_OPTIONS` |
+| bash/zsh  | `unset FLUX_SCHED_OPTIONS`    |
 
-- **./submitter2.lua** #or ./submitter2.py
+`srun --pty --mpi=none -N3 flux start -o,-S,log-filename=out`
 
-- **flux wreck ls**
+`./submitter2.lua` or `./submitter2.py`
+
+3. List jobs in KVS:
+
+`flux wreck ls`
 
 ```
     ID NTASKS STATE                    START      RUNTIME    RANKS COMMAND
@@ -51,7 +67,9 @@ Sschedule/launch both compute and io-forwarding jobs across all nodes
      2      3 running    2018-05-11T17:48:31       3.408s    [0-2] io-forwarding
 ```
 
-- **flux kvs get lwj.0.0.1.R_lite**
+4. Get value stored under job key:
+
+`flux kvs get lwj.0.0.1.R_lite`
 
 ```json
 [ { "node": "quartz23", "children": { "core": "0-3" }, "rank": 0 },
@@ -59,11 +77,10 @@ Sschedule/launch both compute and io-forwarding jobs across all nodes
   { "node": "quartz25", "children": { "core": "0-3" }, "rank": 2 } ]
 ```
 
-- **flux kvs get lwj.0.0.2.R_lite**
+`flux kvs get lwj.0.0.2.R_lite`
 
 ```json
 [ { "node": "quartz23", "children": { "core": "4" }, "rank": 0 },
   { "node": "quartz24", "children": { "core": "4" }, "rank": 1 },
   { "node": "quartz25", "children": { "core": "4" }, "rank": 2 } ]
 ```
-

--- a/example2/submitter.lua
+++ b/example2/submitter.lua
@@ -12,7 +12,7 @@ local compute_jobreq = {
     nnodes = 2,
     ntasks = 4,
     ncores = 8,
-    cmdline = {"compute.lua", "120"}, 
+    cmdline = {"./compute.lua", "120"},
     environ = wreck:get_filtered_env (),
     cwd = posix.getcwd (),
     walltime = 0,
@@ -23,7 +23,7 @@ local io_jobreq = {
     nnodes =  1,
     ntasks =  1,
     ncores =  1,
-    cmdline = {"io-forwarding.lua", "120"},
+    cmdline = {"./io-forwarding.lua", "120"},
     environ = wreck:get_filtered_env (),
     cwd =     posix.getcwd (),
     walltime = 0,
@@ -47,4 +47,3 @@ end
 if resp.errnum then
     print ("flux.rpc: compute_jobreq" .. resp.errnum)
 end
-

--- a/example2/submitter.py
+++ b/example2/submitter.py
@@ -16,7 +16,7 @@ compute_jobreq = {
     'nnodes' : 2,
     'ntasks' : 4,
     'ncores' : 8,
-    'cmdline' : ["compute.py", "120"],
+    'cmdline' : ["./compute.py", "120"],
     'environ' : get_environment (),
     'cwd' : os.getcwd (),
     'walltime' : 0,
@@ -27,7 +27,7 @@ io_jobreq = {
     'nnodes' : 1,
     'ntasks' : 1,
     'ncores' : 1,
-    'cmdline' : ["io-forwarding.py", "120"],
+    'cmdline' : ["./io-forwarding.py", "120"],
     'environ' : get_environment (),
     'cwd' : os.getcwd (),
     'walltime' : 0,
@@ -44,4 +44,3 @@ payload = json.dumps (io_jobreq)
 resp = f.rpc_send ("job.submit", payload)
 if resp is None:
     print "flux.rpc: io_jobreq", "failed"
-

--- a/example2/submitter2.lua
+++ b/example2/submitter2.lua
@@ -12,7 +12,7 @@ local compute_jobreq = {
     nnodes = 3,
     ntasks = 6,
     ncores = 12,
-    cmdline = {"compute.lua", "120"}, 
+    cmdline = {"./compute.lua", "120"},
     environ = wreck:get_filtered_env (),
     cwd = posix.getcwd (),
     walltime = 0,
@@ -23,7 +23,7 @@ local io_jobreq = {
     nnodes =  3,
     ntasks =  3,
     ncores =  3,
-    cmdline = {"io-forwarding.lua", "120"},
+    cmdline = {"./io-forwarding.lua", "120"},
     environ = wreck:get_filtered_env (),
     cwd =     posix.getcwd (),
     walltime = 0,
@@ -47,4 +47,3 @@ end
 if resp.errnum then
     print ("flux.rpc: compute_jobreq" .. resp.errnum)
 end
-

--- a/example2/submitter2.py
+++ b/example2/submitter2.py
@@ -16,7 +16,7 @@ compute_jobreq = {
     'nnodes' : 3,
     'ntasks' : 6,
     'ncores' : 12,
-    'cmdline' : ["compute.py", "120"],
+    'cmdline' : ["./compute.py", "120"],
     'environ' : get_environment (),
     'cwd' : os.getcwd (),
     'walltime' : 0,
@@ -27,7 +27,7 @@ io_jobreq = {
     'nnodes' : 3,
     'ntasks' : 3,
     'ncores' : 3,
-    'cmdline' : ["io-forwarding.py", "120"],
+    'cmdline' : ["./io-forwarding.py", "120"],
     'environ' : get_environment (),
     'cwd' : os.getcwd (),
     'walltime' : 0,
@@ -44,4 +44,3 @@ payload = json.dumps (io_jobreq)
 resp = f.rpc_send ("job.submit", payload)
 if resp is None:
     print "flux.rpc: io_jobreq", "failed"
-


### PR DESCRIPTION
This PR introduces minor changes to the following files:

1. **README.md**
- A table listing of the equivalent commands for setting FLUX_SCHED_OPTIONS in both tcsh and bash/zsh shells.
- Numbers for each step in the sub-examples instead of bullet points.
- Markdown code format for the command line steps in each example instead of bold font.

2. **submitter.py** and **submitter2.py**
- When running the original scripts as is, I would get a "failed" job state when running `flux wreck ls`; see example below:

```
bash-4.2$ flux wreck ls
    ID NTASKS STATE                    START      RUNTIME    RANKS COMMAND
     1      4 failed     2019-10-07T10:14:49       0.174s    [0-1] compute.py
     2      1 failed     2019-10-07T10:14:49       0.137s        2 io-forwarding
```

Adding `./` in front of the scripts to be run in the `cmdline` key-value pair in both dictionaries fixed the problem, and running `flux wreck ls` showed successful "running" and "exited" job states:

```
bash-4.2$ flux wreck ls
    ID NTASKS STATE                    START      RUNTIME    RANKS COMMAND
     2      1 running    2019-10-07T10:15:44       2.291s        2 io-forwarding
     1      4 running    2019-10-07T10:15:44       2.325s    [0-1] compute.py
```
```
bash-4.2$ flux wreck ls
    ID NTASKS STATE                    START      RUNTIME    RANKS COMMAND
     1      4 exited     2019-10-07T10:15:44       2.031m    [0-1] compute.py
     2      1 exited     2019-10-07T10:15:44       2.027m        2 io-forwarding
```

3. **submitter.lua** and **submitter2.lua**

Same changes as described in 2. 