### PR TITLE
doc: Updating README.md and scripts in example4/

### DIFF
--- a/example4/README.md
+++ b/example4/README.md
@@ -1,10 +1,10 @@
-### 1. Job ensemble submitted with a new flux instance
+### Example 4: Job Ensemble Submitted with a New Flux Instance
 
-- Launch a flux instance and submit one instance of io-forwaring job and 50 compute jobs, each spanning the entire set of nodes.
+#### Description: Launch a flux instance and submit one instance of an io-forwarding job and 50 compute jobs, each spanning the entire set of nodes.
 
-- **salloc -N3 -ppdebug** 
+1. `salloc -N3 -ppdebug`
 
-- **cat ensemble.sh**
+2. `cat ensemble.sh`
 
 ```sh
 #!/usr/bin/env sh
@@ -18,7 +18,7 @@ for i in `seq 1 ${NJOBS}`; do
 done
 
 KEY=$(echo $(flux wreck kvs-path 1).state)
-kvs-watch-until.lua -t ${MAXTIME} ${KEY} 'v == "complete"'
+./kvs-watch-until.lua -t ${MAXTIME} ${KEY} 'v == "complete"'
 flux wreck ls -n 100
 
 # print mock-up prevenance data
@@ -26,13 +26,18 @@ for i in `seq 1 $(expr ${NJOBS} + 1)`; do
     echo "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
     echo "Jobid: ${i}"
     echo "Cmdline: " "$(flux kvs get $(flux wreck kvs-path ${i}).cmdline)"
-    echo "$(R_lite.lua ${i})" | sed -e 's/^/Resource: /'
+    echo "$(./R_lite.lua ${i})" | sed -e 's/^/Resource: /'
 done
 ```
 
-- **unsetenv FLUX_SCHED_OPTIONS** *# Make sure the scheduler module will do core-level scheduling*
+3. Make sure the scheduler module will do core-level scheduling:
 
-- **srun --pty --mpi=none -N3 /usr/global/tools/flux/toss_3_x86_64_ib/default/bin/flux start -o,-S,log-filename=out ensemble.sh**
+| Shell     | Command                                        |
+| -----     | ----------                                     |
+| tcsh      | `setenv FLUX_SCHED_OPTIONS "node-excl=true"`   |
+| bash/zsh  | `export FLUX_SCHED_OPTIONS='node-excl=true'`   |
+
+4. `srun --pty --mpi=none -N3 flux start -o,-S,log-filename=out ensemble.sh`
 
 ```
 submit: Submitted jobid 1

--- a/example4/R_lite.lua
+++ b/example4/R_lite.lua
@@ -1,6 +1,6 @@
 #!/usr/bin/env lua
 
-local cpuset = require 'flux.cpuset'
+local cpuset = require 'flux.affinity'.cpuset
 local id_to_kvs_path = require 'wreck'.id_to_path
 local f = assert (require 'flux'.new())
 local jobid = tonumber (arg[1])
@@ -26,7 +26,7 @@ local function usage ()
       Format      if "count" is given, print only the count on the resource(s)
                   if "id", print only the ID of the resource(s)
                   if omitted, print both the count and ID.
-]]) 
+]])
 end
 
 local function r_string (resources, count, id)

--- a/example4/ensemble.sh
+++ b/example4/ensemble.sh
@@ -1,15 +1,15 @@
 #!/usr/bin/env sh
 
 NJOBS=10
-MAXTIME=$(expr ${NJOBS} + 2) 
+MAXTIME=$(expr ${NJOBS} + 2)
 
 flux submit --nnodes=1 --ntasks=1 --cores-per-task=2 ./io-forwarding.lua ${MAXTIME}
 for i in `seq 1 ${NJOBS}`; do
-    flux submit --nnodes=2 --ntasks=4 --cores-per-task=2 ./compute.lua 1 
+    flux submit --nnodes=2 --ntasks=4 --cores-per-task=2 ./compute.lua 1
 done
 
 KEY=$(echo $(flux wreck kvs-path 1).state)
-kvs-watch-until.lua -t ${MAXTIME} ${KEY} 'v == "complete"'
+./kvs-watch-until.lua -t ${MAXTIME} ${KEY} 'v == "complete"'
 flux wreck ls -n 100
 
 # print mock-up prevenance data
@@ -17,5 +17,5 @@ for i in `seq 1 $(expr ${NJOBS} + 1)`; do
     echo "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
     echo "Jobid: ${i}"
     echo "Cmdline: " "$(flux kvs get $(flux wreck kvs-path ${i}).cmdline)"
-    echo "$(R_lite.lua ${i})" | sed -e 's/^/Resource: /'
+    echo "$(./R_lite.lua ${i})" | sed -e 's/^/Resource: /'
 done


### PR DESCRIPTION
This PR introduces minor changes to the following files:

1. **README.md**
- A table listing of the equivalent commands for setting FLUX_SCHED_OPTIONS in both tcsh and bash/zsh shells.
- Numbers for each step in the sub-examples instead of bullet points.
- Markdown code format for the command line steps in each example instead of bold font.
- Removed LC path from `flux` command

2. **ensemble.sh**

Added `./` in front of the scripts to be run in **ensemble.sh** to fix the `command not found` errors when running the script as is.

3. **R_lite.lua**

Changed the `require` statement of `cpuset` from 

`local cpuset = require 'flux.cpuset'`

to

`local cpuset = require 'flux.affinity'.cpuset` (`cpuset` is a member of `flux.affinity`)