### PR TITLE
doc: Update README.md and example scripts in example6/

### DIFF
--- a/example6/README.md
+++ b/example6/README.md
@@ -27,3 +27,8 @@ submit: Submitted jobid 3
 First Level Done
 Mon May 14 19:51:31 PDT 2018
 ```
+
+#### Notes
+
+- You can increase the number of jobs by increasing `NCORES` in `parent.sh` and
+`NJOBS` in `ensemble.sh`.

--- a/example6/README.md
+++ b/example6/README.md
@@ -1,14 +1,19 @@
-### Hierarchical Launching
+### Example 6 - Hierarchical Launching
 
-- Launching over one million sleep 0 task
+#### Description: Launch a very large ensemble of sleep 0 tasks
 
-- **salloc -N3 -ppdebug** 
+1. `salloc -N3 -ppdebug`
 
-- **setenv FLUX_SCHED_OPTIONS "node-excl=true"** *# Make sure the scheduler module will do core-level scheduling*
+2. Make sure the scheduler module will do core-level scheduling:
 
-- **srun --pty --mpi=none -N3 /usr/global/tools/flux/toss_3_x86_64_ib/default/bin/flux start -o,-S,log-filename=out**
+| Shell     | Command                       |
+| -----     | ----------                    |
+| tcsh      | `unsetenv FLUX_SCHED_OPTIONS` |
+| bash/zsh  | `unset FLUX_SCHED_OPTIONS`    |
 
-- **parent.sh**
+3. `srun --pty --mpi=none -N3 flux start -o,-S,log-filename=out`
+
+`./parent.sh`
 
 ```
 Mon May 14 19:42:08 PDT 2018

--- a/example6/ensemble.sh
+++ b/example6/ensemble.sh
@@ -1,14 +1,13 @@
 #!/usr/bin/env sh
 
-NJOBS=5000
-MAXTIME=$(expr ${NJOBS} + 2) 
+NJOBS=750
+MAXTIME=$(expr ${NJOBS} + 2)
 
 for i in `seq 1 ${NJOBS}`; do
     flux submit --nnodes=1 --ntasks=1 --cores-per-task=1 sleep 0
 done
 
 KEY=$(echo $(flux wreck kvs-path ${NJOBS}).state)
-kvs-watch-until.lua -t ${MAXTIME} ${KEY} 'v == "complete"'
+./kvs-watch-until.lua -t ${MAXTIME} ${KEY} 'v == "complete"'
 flux wreck ls -n 100
 echo "Final Level Done"
-

--- a/example6/parent.sh
+++ b/example6/parent.sh
@@ -1,15 +1,15 @@
 #!/usr/bin/env sh
 
-NCORES=216
+NCORES=3
 
 date
 
 for i in `seq 1 ${NCORES}`; do
-    flux submit -N 1 -n 1 flux start -s1 ensemble.sh
+    flux submit -N 1 -n 1 flux start ./ensemble.sh
 done
 
 KEY=$(echo $(flux wreck kvs-path ${NCORES}).state)
-kvs-watch-until.lua -t 1000 ${KEY} 'v == "complete"'
+./kvs-watch-until.lua -t 1000 ${KEY} 'v == "complete"'
 flux wreck ls
 echo "First Level Done"
 


### PR DESCRIPTION
This PR introduces the following changes to three files in this repository:

**README.md**
Changed format of instructions on example code; set example instructions for unsetting environment variable `FLUX_SCHED_OPTIONS` in both tcsh and bash/zsh shells.

**parent.sh**
Changed `NCORES` in from 216 to 3, and removed `-s1` flag from `flux submit` command.

**ensemble.sh**
Changed `NJOBS` from 5000 to 750.