### PR TITLE
[flux-core v0.11] doc: Update README.md in example5/

### DIFF
--- a/example5/README.md
+++ b/example5/README.md
@@ -1,12 +1,32 @@
-### Using a Flux comms module to comminicate with job elements
+### Example 5 - Using a Flux Comms Module
 
-- **salloc -N3 -ppdebug** 
+#### Description: Use a Flux comms module to communicate with job elements
 
-- **setenv FLUX_SCHED_OPTIONS "node-excl=true"** *# Make sure the scheduler module will do node-exclusive scheduling*
+1. `salloc -N3 -ppdebug`
 
-- **srun --pty --mpi=none -N3 /usr/global/tools/flux/toss_3_x86_64_ib/default/bin/flux start -o,-S,log-filename=out**
+2. Point to `flux-core`'s `pkgconfig` directory:
 
-- **flux submit -N 2 -n 2 compute.lua 120**
+| Shell     | Command                                                      |
+| -----     | ----------                                                   |
+| tcsh      | `setenv PKG_CONFIG_PATH <FLUX_INSTALL_PATH>/lib/pkgconfig`   |
+| bash/zsh  | `export PKG_CONFIG_PATH='<FLUX_INSTALL_PATH>/lib/pkgconfig'` |
 
-- **flux submit -N 2 -n 2 io-forwarding.lua 120**
+3. `make`
 
+4. Add the directory of the modules to `FLUX_MODULE_PATH`; if the module was
+built in the current dir:
+
+`export FLUX_MODULE_PATH=${FLUX_MODULE_PATH}:$(pwd)`
+
+5. Make sure the scheduler module will do node-exclusive scheduling:
+
+| Shell     | Command                                        |
+| -----     | ----------                                     |
+| tcsh      | `setenv FLUX_SCHED_OPTIONS "node-excl=true"`   |
+| bash/zsh  | `export FLUX_SCHED_OPTIONS='node-excl=true'`   |
+
+6. `srun --pty --mpi=none -N3 flux start -o,-S,log-filename=out`
+
+7. `flux submit -N 2 -n 2 ./compute.lua 120`
+
+8. `flux submit -N 1 -n 1 ./io-forwarding.lua 120`

--- a/example5/compute.lua
+++ b/example5/compute.lua
@@ -4,6 +4,7 @@ local f, err = require 'flux' .new ()
 local amount = tonumber (arg[1]) or 120
 local rank = tonumber (os.getenv('FLUX_TASK_RANK')) or 0
 local frank = tonumber (os.getenv('FLUX_LOCAL_RANKS')) or 0
+io.stdout:setvbuf ("no")
 
 local function sleep (n)
     os.execute ("sleep " .. n)
@@ -55,7 +56,7 @@ else
 end
 
 print ("Will compute for " .. amount .. " seconds")
-sleep (amount) 
+sleep (amount)
 f:unsubscribe ("app.io.go")
 
 -- vi: ts=4 sw=4 expandtab

--- a/example5/io-forwarding.lua
+++ b/example5/io-forwarding.lua
@@ -5,6 +5,7 @@ local f = flux.new ()
 local amount = tonumber (arg[1]) or 120
 local rank = tonumber (os.getenv('FLUX_TASK_RANK')) or 0
 local frank = tonumber (os.getenv('FLUX_LOCAL_RANKS')) or 0
+io.stdout:setvbuf ("no")
 
 local function sleep (n)
     os.execute ("sleep " .. n)
@@ -50,7 +51,7 @@ if not resp then
 end
 
 print ("Will forward IO requests for " .. amount .. " seconds")
-sleep (amount) 
+sleep (amount)
 f:unsubscribe ("app.comp.go")
 
 -- vi: ts=4 sw=4 expandtab


### PR DESCRIPTION
Oops, I'm sorry! When submitting all of these PR's I must have forgotten to submit this specific example. 

This PR makes the following changes to **README.md**:

- Added numbers to instructions
- A table listing of the equivalent commands for setting FLUX_SCHED_OPTIONS in both tcsh and bash/zsh shells.
- Added code format to step-by-step instructions
- Changed allocation for `io-forwarding.lua` script 
- Added a note to user to inform them that output might not show up until all tasks complete. 