### PR TITLE
[flux-core v0.13] example5: Update README, app.c, and Lua scripts

### DIFF
--- a/example5/README.md
+++ b/example5/README.md
@@ -1,12 +1,25 @@
-### Using a Flux comms module to comminicate with job elements
+### Example 5 - Using a Flux Comms Module
 
-- **salloc -N3 -ppdebug** 
+#### Description: Use a Flux comms module to communicate with job elements
 
-- **setenv FLUX_SCHED_OPTIONS "node-excl=true"** *# Make sure the scheduler module will do node-exclusive scheduling*
+1. `salloc -N3 -ppdebug`
 
-- **srun --pty --mpi=none -N3 /usr/global/tools/flux/toss_3_x86_64_ib/default/bin/flux start -o,-S,log-filename=out**
+2. Point to `flux-core`'s `pkgconfig` directory:
 
-- **flux submit -N 2 -n 2 compute.lua 120**
+| Shell     | Command                                                      |
+| -----     | ----------                                                   |
+| tcsh      | `setenv PKG_CONFIG_PATH <FLUX_INSTALL_PATH>/lib/pkgconfig`   |
+| bash/zsh  | `export PKG_CONFIG_PATH='<FLUX_INSTALL_PATH>/lib/pkgconfig'` |
 
-- **flux submit -N 2 -n 2 io-forwarding.lua 120**
+3. `make`
 
+4. Add the directory of the modules to `FLUX_MODULE_PATH`; if the module was
+built in the current dir:
+
+`export FLUX_MODULE_PATH=${FLUX_MODULE_PATH}:$(pwd)`
+
+5. `srun --pty --mpi=none -N3 flux start -o,-S,log-filename=out`
+
+6. `flux submit -N 2 -n 2 ./compute.lua 120`
+
+7. `flux submit -N 1 -n 1 ./io-forwarding.lua 120`

--- a/example5/app.c
+++ b/example5/app.c
@@ -57,7 +57,7 @@ static void io_request_cb (flux_t *h, flux_msg_handler_t *w,
 
 error:
     flux_log_error (h, "%s", __FUNCTION__);
-    if (flux_respond (h, msg, errno, NULL) < 0)
+    if (flux_respond (h, msg, NULL) < 0)
         flux_log_error (h, "%s: flux_respond", __FUNCTION__);
 }
 #endif
@@ -81,7 +81,7 @@ static void comp_request_cb (flux_t *h, flux_msg_handler_t *w,
 
 error:
     flux_log_error (h, "%s", __FUNCTION__);
-    if (flux_respond (h, msg, errno, NULL) < 0)
+    if (flux_respond (h, msg, NULL) < 0)
         flux_log_error (h, "%s: flux_respond", __FUNCTION__);
 }
 #endif

--- a/example5/compute.lua
+++ b/example5/compute.lua
@@ -4,6 +4,7 @@ local f, err = require 'flux' .new ()
 local amount = tonumber (arg[1]) or 120
 local rank = tonumber (os.getenv('FLUX_TASK_RANK')) or 0
 local frank = tonumber (os.getenv('FLUX_LOCAL_RANKS')) or 0
+io.stdout:setvbuf ("no")
 
 local function sleep (n)
     os.execute ("sleep " .. n)
@@ -55,7 +56,7 @@ else
 end
 
 print ("Will compute for " .. amount .. " seconds")
-sleep (amount) 
+sleep (amount)
 f:unsubscribe ("app.io.go")
 
 -- vi: ts=4 sw=4 expandtab

--- a/example5/io-forwarding.lua
+++ b/example5/io-forwarding.lua
@@ -5,6 +5,7 @@ local f = flux.new ()
 local amount = tonumber (arg[1]) or 120
 local rank = tonumber (os.getenv('FLUX_TASK_RANK')) or 0
 local frank = tonumber (os.getenv('FLUX_LOCAL_RANKS')) or 0
+io.stdout:setvbuf ("no")
 
 local function sleep (n)
     os.execute ("sleep " .. n)
@@ -50,7 +51,7 @@ if not resp then
 end
 
 print ("Will forward IO requests for " .. amount .. " seconds")
-sleep (amount) 
+sleep (amount)
 f:unsubscribe ("app.comp.go")
 
 -- vi: ts=4 sw=4 expandtab


### PR DESCRIPTION
This PR makes the following changes:

1. **README.md**:

- Update instructions to include setting `PKG_CONFIG_PATH` and `FLUX_MODULE_PATH`
- Add numbered instructions instead of bullet points
- Change instructions from **bold** font to `in-line code`

2. **app.c**

- Update use of `flux_respond()` to remove unnecessary third parameter

3. **compute.lua** and **io-forwarding.lua**

- Add I/O flushing to both scripts 

Thanks @dongahn for helping me debug these issues! 