### PR TITLE
[flux-core v0.13] example 7 update: Update bookkeeper script, README, blacken Python scripts

### DIFF
--- a/example7/README.md
+++ b/example7/README.md
@@ -47,7 +47,7 @@ bookkeeper: all jobs completed
 
 
 - The following constructs a job request using the **JobspecV1** class with customizable parameters for how you want to utilize the resources allocated for your job:
-```
+```python
 compute_jobreq = JobspecV1.from_command(
     command=["./compute.py", "120"], num_tasks=4, num_nodes=2, cores_per_task=2
 )
@@ -58,11 +58,11 @@ compute_jobreq.environment = dict(os.environ)
 - `flux.job.submit(f, compute_jobreq)` submits the job to be run, and returns a job ID once it begins running.
 
 - Throughout the course of a job, its state will go through a number of changes. The following subscribes to the event messages matching the transition of those states in the jobs submitted.
-```
+```python
 f.event_subscribe("job-state")
 f.msg_watcher_create(job_state_cb, 0, "job-state").start()
 submit_bundles(f, args.integer)
-print "bookkeeper: waiting until all jobs complete
+print("bookkeeper: waiting until all jobs complete)
 f.reactor_run(f.get_reactor(), 0)
-print "bookkeeper: all jobs completed"
+print("bookkeeper: all jobs completed")
 ```

--- a/example7/README.md
+++ b/example7/README.md
@@ -1,30 +1,34 @@
-### Using Flux job status and control API
+### Example 7 - Using Flux Job Status and Control API
 
-Submit job bundles and wait until all jobs complete
+#### Description: Submit job bundles and wait until all jobs complete
 
-- **salloc -N3 -ppdebug**
+1. `salloc -N3 -ppdebug`
 
-- **unsetenv FLUX_SCHED_OPTIONS**
+2. `srun --pty --mpi=none -N3 flux start -o,-S,log-filename=out`
 
-- **srun --pty --mpi=none -N3 /usr/global/tools/flux/toss_3_x86_64_ib/default/bin/flux start -o,-S,log-filename=out**
-
-- **./bookkeeper.py 5**
-
+3. `./bookkeeper.py 5`
 
 ```
-bookkeeper: all jobs submited
+bookkeeper: all jobs submitted
 bookkeeper: waiting until all jobs complete
+job 1417322430464 changed its state to DEPEND
+job 1417322430464 changed its state to SCHED
+job 1417758638080 changed its state to DEPEND
+job 1417758638080 changed its state to SCHED
+job 1418161291264 changed its state to DEPEND
+job 1418161291264 changed its state to SCHED
+.
+.
+.
+job 282058555392 changed its state to CLEANUP
+job 285564993536 changed its state to CLEANUP
+.
+.
+.
+job 282058555392 changed its state to INACTIVE
+job 285564993536 changed its state to INACTIVE
+.
+.
+.
 bookkeeper: all jobs completed
-    ID NTASKS STATE                    START      RUNTIME    RANKS COMMAND
-     1      6 exited     2018-05-18T18:48:01       5.724s    [0-2] compute.py
-     2      3 exited     2018-05-18T18:48:01       5.742s    [0-2] io-forwarding
-     3      6 exited     2018-05-18T18:48:01       5.729s    [0-2] compute.py
-     4      3 exited     2018-05-18T18:48:01       5.647s    [0-2] io-forwarding
-     5      6 exited     2018-05-18T18:48:01       5.661s    [0-2] compute.py
-     6      3 exited     2018-05-18T18:48:01       5.611s    [0-2] io-forwarding
-     7      6 exited     2018-05-18T18:48:01       5.667s    [0-2] compute.py
-     8      3 exited     2018-05-18T18:48:01       5.633s    [0-2] io-forwarding
-     9      6 exited     2018-05-18T18:48:01       5.583s    [0-2] compute.py
-    10      3 exited     2018-05-18T18:48:01       5.608s    [0-2] io-forwarding
 ```
-

--- a/example7/bookkeeper.py
+++ b/example7/bookkeeper.py
@@ -3,89 +3,69 @@
 import json
 import os
 import flux
-from flux import jsc
 import argparse
 
-def get_environment():
-    env = dict()
-    for key in os.environ:
-        env[key] = os.environ[key]
-    return env
+compute_jobreq = JobspecV1.from_command(
+    command=["./compute.py", "120"], num_tasks=6, num_nodes=3, cores_per_task=2
+)
+compute_jobreq.cwd = os.getcwd()
+compute_jobreq.environment = dict(os.environ)
 
-# Compute job spec
-compute_jobreq = {
-    'nnodes' : 3,
-    'ntasks' : 6,
-    'ncores' : 12,
-    'cmdline' : ["./compute.py", "5"],
-    'environ' : get_environment (),
-    'cwd' : os.getcwd (),
-    'walltime' : 0,
-    'ngpus' : 0,
-    'options': {'nokz': False},
-}
-
-# IO forward job spec
-io_jobreq = {
-    'nnodes' : 3,
-    'ntasks' : 3,
-    'ncores' : 3,
-    'cmdline' : ["./io-forwarding.py", "5"],
-    'environ' : get_environment (),
-    'cwd' : os.getcwd (),
-    'walltime' : 0,
-    'ngpus' : 0,
-    'options': {'nokz': False},
-}
+io_jobreq = JobspecV1.from_command(
+    command=["./io-forwarding.py", "120"], num_tasks=3, num_nodes=3, cores_per_task=1
+)
+io_jobreq.cwd = os.getcwd()
+io_jobreq.environment = dict(os.environ)
 
 njobs = 0
 
-# Get called everytime a job changes its state
-def jsc_cb (jcbstr, arg, errnum):
-    global njobs   
-    (f, N) = arg 
-    jcb = json.loads (jcbstr)
-    jobid = jcb['jobid']
-    state = jsc.job_num2state (jcb[jsc.JSC_STATE_PAIR][jsc.JSC_STATE_PAIR_NSTATE])
-    #print "flux.jsc: job", jobid, "changed its state to ", state
-    if state == "complete": 
-        njobs += 1
-    if njobs == N:
-        f.reactor_stop (f.get_reactor ())
 
-# Submit bundles of jobs using flux submit RPC
-def submit_bundles (f, N):
-    for i in range (0, N):
-         payload = json.dumps (compute_jobreq)
-         resp = f.rpc_send ("job.submit", payload)
-         if resp is None:
-              raise RuntimeError ("flux.rpc: compute_jobreq")
+def job_state_cb(f, typemask, message, arg):
+    global njobs
+    N = args.integer
+    for jobid, state in message.payload["transitions"]:
+        print ("job " + str(jobid) + " changed its state to " + str(state))
+        if state == "INACTIVE":
+            njobs += 1
+        if njobs == N * 2:
+            f.reactor_stop(f.get_reactor())
 
-         payload = json.dumps (io_jobreq)
-         resp = f.rpc_send ("job.submit", payload)
-         if resp is None:
-              raise RuntimeError ("flux.rpc: io_jobreq")
+
+# submit bundles of jobs using flux.job.submit ()
+def submit_bundles(f, N):
+    f = flux.Flux()
+    for i in range(0, N):
+        print (flux.job.submit(f, compute_jobreq))
+        print (flux.job.submit(f, io_jobreq))
+
     print "bookkeeper: all jobs submited"
 
-# Main
-def main ():
-    parser = argparse.ArgumentParser (description=
-                 'submit and wait for the completion of '
-                 'N bundles, each consisting of compute '
-                 'and io-forwarding jobs')
-    parser.add_argument ('integer', metavar='N', type=int,
-                         help='the number of bundles to submit and wait')
-    args = parser.parse_args ()
 
-    f = flux.Flux ()
-    jsc.notify_status (f, jsc_cb, (f, args.integer * 2)) 
-    submit_bundles (f, args.integer)
+# main
+def main():
+    parser = argparse.ArgumentParser(
+        description="submit and wait for the completion of "
+        "N bundles, each consisting of compute "
+        "and io-forwarding jobs"
+    )
+    parser.add_argument(
+        "integer",
+        metavar="N",
+        type=int,
+        help="the number of bundles to submit and wait",
+    )
+    global args
+    args = parser.parse_args()
+
+    f = flux.Flux()
+    f.event_subscribe("job-state")
+    f.msg_watcher_create(job_state_cb, 0, "job-state").start()
+    submit_bundles(f, args.integer)
     print "bookkeeper: waiting until all jobs complete"
-    f.reactor_run (f.get_reactor (), 0)
+    f.reactor_run(f.get_reactor(), 0)
     print "bookkeeper: all jobs completed"
-    cmd = "flux wreck ls -n " + str (args.integer * 2)
-    os.system (cmd)
 
-main ()
+
+main()
 
 # vi: ts=4 sw=4 expandtab

--- a/example7/bookkeeper.py
+++ b/example7/bookkeeper.py
@@ -38,7 +38,7 @@ def submit_bundles(f, N):
         print (flux.job.submit(f, compute_jobreq))
         print (flux.job.submit(f, io_jobreq))
 
-    print "bookkeeper: all jobs submited"
+    print "bookkeeper: all jobs submitted"
 
 
 # main

--- a/example7/bookkeeper.py
+++ b/example7/bookkeeper.py
@@ -24,7 +24,7 @@ def job_state_cb(f, typemask, message, arg):
     global njobs
     N = args.integer
     for jobid, state in message.payload["transitions"]:
-        print ("job " + str(jobid) + " changed its state to " + str(state))
+        print("job " + str(jobid) + " changed its state to " + str(state))
         if state == "INACTIVE":
             njobs += 1
         if njobs == N * 2:
@@ -35,10 +35,10 @@ def job_state_cb(f, typemask, message, arg):
 def submit_bundles(f, N):
     f = flux.Flux()
     for i in range(0, N):
-        print (flux.job.submit(f, compute_jobreq))
-        print (flux.job.submit(f, io_jobreq))
+        print(flux.job.submit(f, compute_jobreq))
+        print(flux.job.submit(f, io_jobreq))
 
-    print "bookkeeper: all jobs submitted"
+    print("bookkeeper: all jobs submitted")
 
 
 # main
@@ -61,9 +61,9 @@ def main():
     f.event_subscribe("job-state")
     f.msg_watcher_create(job_state_cb, 0, "job-state").start()
     submit_bundles(f, args.integer)
-    print "bookkeeper: waiting until all jobs complete"
+    print("bookkeeper: waiting until all jobs complete")
     f.reactor_run(f.get_reactor(), 0)
-    print "bookkeeper: all jobs completed"
+    print("bookkeeper: all jobs completed")
 
 
 main()

--- a/example7/compute.py
+++ b/example7/compute.py
@@ -3,12 +3,15 @@
 import argparse
 import time
 
-parser = argparse.ArgumentParser (description='compute for seconds')
-parser.add_argument ('integer', metavar='S', type=int,
-                     help='an integer for the number of seconds to compute')
+parser = argparse.ArgumentParser(description="compute for seconds")
+parser.add_argument(
+    "integer",
+    metavar="S",
+    type=int,
+    help="an integer for the number of seconds to compute",
+)
 
-args = parser.parse_args ()
+args = parser.parse_args()
 
-print "Will compute for " + str (args.integer) + " seconds."
-time.sleep (args.integer)
-
+print "Will compute for " + str(args.integer) + " seconds."
+time.sleep(args.integer)

--- a/example7/compute.py
+++ b/example7/compute.py
@@ -13,5 +13,5 @@ parser.add_argument(
 
 args = parser.parse_args()
 
-print "Will compute for " + str(args.integer) + " seconds."
+print("Will compute for " + str(args.integer) + " seconds.")
 time.sleep(args.integer)

--- a/example7/io-forwarding.py
+++ b/example7/io-forwarding.py
@@ -3,12 +3,15 @@
 import argparse
 import time
 
-parser = argparse.ArgumentParser (description='forward I/O requests for seconds')
-parser.add_argument ('integer', metavar='S', type=int,
-                     help='an integer for the number of seconds to compute')
+parser = argparse.ArgumentParser(description="forward I/O requests for seconds")
+parser.add_argument(
+    "integer",
+    metavar="S",
+    type=int,
+    help="an integer for the number of seconds to compute",
+)
 
-args = parser.parse_args ()
+args = parser.parse_args()
 
-print "Will forward I/O requests for " + str (args.integer) + " seconds."
-time.sleep (args.integer)
-
+print "Will forward I/O requests for " + str(args.integer) + " seconds."
+time.sleep(args.integer)

--- a/example7/io-forwarding.py
+++ b/example7/io-forwarding.py
@@ -13,5 +13,5 @@ parser.add_argument(
 
 args = parser.parse_args()
 
-print "Will forward I/O requests for " + str(args.integer) + " seconds."
+print("Will forward I/O requests for " + str(args.integer) + " seconds.")
 time.sleep(args.integer)


### PR DESCRIPTION
This PR proposes the following changes:

1. **README.md**
- Update format of instructions from bullet points to numbered instructions
- Remove instruction to set `FLUX_SCHED_OPTIONS` environment variable
- Update example output to match new **bookkeeper.py** script

2. **bookkeeper.py**
- Update job submissions in script to comply with new Python bindings, create new callback function that waits for jobs to transition to `INACTIVE` state

3. **compute.py** and **io-forwarding.py**
- Blacken both scripts

