### PR TITLE
[flux-core v0.13] example9 update: Update kvsput-usrdata.py, README.md

### DIFF
--- a/example9/README.md
+++ b/example9/README.md
@@ -1,30 +1,56 @@
-### Simple KVS Python binding examples
+### Example 9 - KVS Python Binding Example
 
-- Using kvs python interfaces to store user data into kvs
+#### Description: Use the KVS Python interface to store user data into KVS
 
-- **/usr/global/tools/flux/toss_3_x86_64_ib/default/bin/flux start -s 1 -o,-S,log-filename=out**
+1. Launch a Flux instance by running `flux start`, redirecting log messages to the file `out` in the current directory:
 
-- **flux submit -N 1 -n 1 kvsput-usrdata.py **
+`flux start -s 1 -o,-S,log-filename=out`
 
-```
-submit: Submitted jobid 1
-```
+2. Submit the Python script:
 
-- **flux wreck attach 1**
+`flux submit -N 1 -n 1 ./kvsput-usrdata.py`
 
 ```
-mydata
-mydata2
+6705031151616
 ```
 
-- **flux kvs get lwj.0.0.1.usrdata**
+3. Attach to the job and view output:
+
+`flux job attach 6705031151616`
 
 ```
-"mydata"
+hello world
+hello world again
 ```
 
-- **flux kvs get lwj.0.0.1.usrdata2**
+4. Each job is run within a KVS namespace. `FLUX_KVS_NAMESPACE` is set, which is automatically read and used by the KVS operations in the handle. To take a look at the job's KVS, convert its job ID to KVS:
+
+`flux job id --from=dec --to=kvs 6705031151616`
 
 ```
-"mydata2"
+job.0000.0619.2300.0000
 ```
+
+5. The keys for this job will be put at the root of the namespace, which is mounted under "guest". To get the value stored under the first key "usrdata":
+
+`flux kvs get job.0000.0619.2300.0000.guest.usrdata`
+
+```
+"hello world"
+```
+
+6. Get the value stored under the second key "usrdata2":
+
+`flux kvs get job.0000.0619.2300.0000.guest.usrdata2`
+
+```
+"hello world again"
+```
+
+##### Notes
+
+- `f = flux.Flux()` creates a new Flux handle which can be used to connect to and interact with a Flux instance.
+
+- `kvs.put()` places the value of _udata_ under the key **"usrdata"**. Once the key-value pair is put, the change must be committed with `kvs.commit()`. The value can then be retrieved with `kvs.get()`
+
+- `kvs.get()` on a directory will return a KVSDir object which supports the `with` compound statement. `with` guarantees a commit is called on the directory.

--- a/example9/kvsput-usrdata.py
+++ b/example9/kvsput-usrdata.py
@@ -13,9 +13,9 @@ kvs.put (f, "usrdata", udata)
 kvs.commit (f)
 print kvs.get (f, "usrdata")
 
-# get on a directory will return KVSDir object which support
-# with compound statement. "with" guarantees commit is called
-# on the directory if job_path is a valid input.
+# get() on a directory will return a KVSDir object which supports
+# the "with" compound statement. "with" guarantees a commit is called
+# on the directory.
 with kvs.get (f, ".") as kd:
    kd['usrdata2'] = "hello world again"
 

--- a/example9/kvsput-usrdata.py
+++ b/example9/kvsput-usrdata.py
@@ -6,20 +6,19 @@ import os
 from flux import kvs
 
 f = flux.Flux ()
-job_path = os.environ['FLUX_JOB_KVSPATH']
-udata = job_path + ".usrdata"
+udata = "hello world"
 # using function interface
-kvs.put (f, udata, "mydata")
+kvs.put (f, "usrdata", udata)
 # commit is required to effect the above put op to the server
 kvs.commit (f)
-print kvs.get (f, udata)
+print kvs.get (f, "usrdata")
 
 # get on a directory will return KVSDir object which support
 # with compound statement. "with" guarantees commit is called
 # on the directory if job_path is a valid input.
-with kvs.get (f, job_path) as kd:
-   kd['usrdata2'] = "mydata2"
+with kvs.get (f, ".") as kd:
+   kd['usrdata2'] = "hello world again"
 
-print kvs.get (f, job_path + ".usrdata2")
+print kvs.get (f, "usrdata2")
 
 # vi: ts=4 sw=4 expandtab


### PR DESCRIPTION
This PR makes the following changes:

**kvsput-usrdata.py**

- update script to comply with new KVS Python interface 
- remove unneeded `FLUX_JOB_KVSPATH` environment variable from script

**README.md**

- update format of instructions from **bold** font to `in-line` code
- change order of instructions from bullet points to numbered instructions
- add descriptions for some of the instructions dealing with KVS interface and added a **Notes** section that goes into some detail about the commands in `kvsput-usrdata.py`