### PR TITLE
[flux-core v0.13] example9: fix incorrect title in header

### DIFF
--- a/example9/README.md
+++ b/example9/README.md
@@ -1,4 +1,4 @@
-### Example10 - A Data Conduit Strategy
+### Example 9 - A Data Conduit Strategy
 
 #### Description: Use a data stream to send packets through
 


### PR DESCRIPTION
Thanks @SteVwonder for pointing out the incorrect header on example 9's **README.md** (Issue #48). This small PR fixes that by changing the header from **Example 10** to **Example 9**. 