### PR TITLE
add new example: Python Job Submit/Wait Example

### DIFF
--- a/example10/README.md
+++ b/example10/README.md
@@ -1,0 +1,139 @@
+### Example 10(a) - Python Job Submit/Wait
+
+#### Description: Submit jobs asynchronously and wait for them to complete in any order
+
+1. Allocate three nodes from a resource manager:
+
+`salloc -N3 -ppdebug`
+
+2. Launch a Flux instance on the current allocation by running `flux start` once per node, redirecting log messages to the file `out` in the current directory:
+
+`srun --pty --mpi=none -N3 flux start -o,-S,log-filename=out`
+
+3. Submit the **submitter_wait_any.py** script, along with the number of jobs you want to run (if no argument is passed, 10 jobs are submitted):
+
+`./submitter_wait_any.py 10`
+
+```
+submit: 11123713638400 compute_jobspec
+submit: 11124099514368 compute_jobspec
+submit: 11124518944768 compute_jobspec
+submit: 11124921597952 compute_jobspec
+submit: 11125257142272 compute_jobspec
+submit: 11125626241024 bad_jobspec
+submit: 11126028894208 bad_jobspec
+submit: 11126347661312 bad_jobspec
+submit: 11126649651200 bad_jobspec
+submit: 11126968418304 bad_jobspec
+wait: 11123713638400 Success
+wait: 11124099514368 Success
+wait: 11124518944768 Success
+wait: 11124921597952 Success
+wait: 11125257142272 Success
+wait: 11125626241024 Error: task(s) exited with exit code 1
+wait: 11126028894208 Error: task(s) exited with exit code 1
+wait: 11126347661312 Error: task(s) exited with exit code 1
+wait: 11126649651200 Error: task(s) exited with exit code 1
+wait: 11126968418304 Error: task(s) exited with exit code 1
+```
+
+---
+
+### Example 10(b) - Python Job Submit/Wait (Sliding Window)
+
+#### Description: Asynchronously submit jobs and keep at most a number of those jobs active
+
+1. Allocate three nodes from a resource manager:
+
+`salloc -N3 -ppdebug`
+
+2. Launch a Flux instance on the current allocation by running `flux start` once per node, redirecting log messages to the file `out` in the current directory:
+
+`srun --pty --mpi=none -N3 flux start -o,-S,log-filename=out`
+
+3. Submit the **submitter_sliding_window.py** script, along with the number of jobs you want to run and the size of the window (if no argument is passed, 10 jobs are submitted and the window size is 2 jobs):
+
+`./submitter_sliding_window.py 10 3`
+
+```
+submit: 5624175788032
+submit: 5624611995648
+submit: 5625014648832
+wait: 5624175788032 Success
+submit: 5804329533440
+wait: 5624611995648 Success
+submit: 5804648300544
+wait: 5625014648832 Success
+submit: 5805084508160
+wait: 5804329533440 Success
+submit: 5986144223232
+wait: 5804648300544 Success
+submit: 5986462990336
+wait: 5805084508160 Success
+submit: 5986882420736
+wait: 5986144223232 Success
+submit: 6164435697664
+wait: 5986462990336 Success
+wait: 5986882420736 Success
+wait: 6164435697664 Success
+```
+
+---
+
+### Example 10(c) - Python Job Submit/Wait (Specific Job ID)
+
+#### Description: Asynchronously submit jobs, block/wait for specific jobs to complete
+
+1. Allocate three nodes from a resource manager:
+
+`salloc -N3 -ppdebug`
+
+2. Launch a Flux instance on the current allocation by running `flux start` once per node, redirecting log messages to the file `out` in the current directory:
+
+`srun --pty --mpi=none -N3 flux start -o,-S,log-filename=out`
+
+3. Submit the **submitter_wait_in_order.py** script, along with the number of jobs you want to run (if no argument is passed, 10 jobs are submitted):
+
+`./submitter_wait_in_order.py 10`
+
+```
+submit: 141868138496 compute_jobspec
+submit: 142203682816 compute_jobspec
+submit: 142639890432 compute_jobspec
+submit: 143025766400 compute_jobspec
+submit: 143344533504 compute_jobspec
+submit: 143730409472 bad_jobspec
+submit: 144233725952 bad_jobspec
+submit: 144518938624 bad_jobspec
+submit: 144871260160 bad_jobspec
+submit: 145156472832 bad_jobspec
+wait: 143730409472 Error: task(s) exited with exit code 1
+wait: 144518938624 Error: task(s) exited with exit code 1
+wait: 145156472832 Error: task(s) exited with exit code 1
+wait: 144871260160 Error: task(s) exited with exit code 1
+wait: 144233725952 Error: task(s) exited with exit code 1
+wait: 141868138496 Success
+wait: 143025766400 Success
+wait: 142639890432 Success
+wait: 143344533504 Success
+wait: 142203682816 Success
+```
+
+---
+
+##### Notes
+
+- `h = flux.Flux()` creates a new Flux handle which can be used to connect to and interact with a Flux instance.
+
+- The following constructs a job request using the **JobspecV1** class with customizable parameters for how you want to utilize the resources allocated for your job:
+
+```python
+# create jobspec for compute.py
+compute_jobspec = JobspecV1.from_command(command=["./compute.py", "15"], num_tasks=4, num_nodes=2, cores_per_task=2)
+compute_jobspec.cwd = os.getcwd()
+compute_jobspec.environment = dict(os.environ)
+```
+
+- `flux.job.submit(h, compute_jobspec, flags=flags)` submits the job to be run, and returns a job ID once it begins running.
+
+- `result = job.wait(h, jobid)` waits for a job to transition to the **INACTIVE** state, then returns a summary of the job result, either a **Success** or an **Error** string.

--- a/example10/compute.py
+++ b/example10/compute.py
@@ -1,0 +1,17 @@
+#!/usr/bin/env python
+
+import argparse
+import time
+
+parser = argparse.ArgumentParser(description="compute for seconds")
+parser.add_argument(
+    "integer",
+    metavar="S",
+    type=int,
+    help="an integer for the number of seconds to compute",
+)
+
+args = parser.parse_args()
+
+print "Will compute for " + str(args.integer) + " seconds."
+time.sleep(args.integer)

--- a/example10/submitter_sliding_window.py
+++ b/example10/submitter_sliding_window.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python
+
+import flux
+import sys
+import os
+
+from flux import job
+from flux.job import JobspecV1
+
+njobs = 10
+window_size = 2
+if len(sys.argv) >= 2:
+    njobs = int(sys.argv[1])
+if len(sys.argv) == 3:
+    window_size = int(sys.argv[2])
+
+# open connection to broker
+h = flux.Flux()
+
+# create jobspec for compute.py
+compute_jobspec = JobspecV1.from_command(
+    command=["./compute.py", "5"], num_tasks=4, num_nodes=2, cores_per_task=2
+)
+compute_jobspec.cwd = os.getcwd()
+compute_jobspec.environment = dict(os.environ)
+
+flags = flux.constants.FLUX_JOB_WAITABLE
+done = 0
+running = 0
+
+# submit jobs, keep [window_size] jobs running
+while done < njobs:
+    if running < window_size and done + running < njobs:
+        jobid = flux.job.submit(h, compute_jobspec, flags=flags)
+        print("submit: {}".format(jobid))
+        running += 1
+
+    if running == window_size or done + running == njobs:
+        jobid, success, errstr = job.wait(h)
+        if success:
+            print("wait: {} Success".format(jobid))
+        else:
+            print("wait: {} Error: {}".format(jobid, errstr))
+        done += 1
+        running -= 1
+
+# vim: tabstop=4 shiftwidth=4 expandtab

--- a/example10/submitter_wait_any.py
+++ b/example10/submitter_wait_any.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python
+
+import json
+import os
+import sys
+import flux
+
+from flux import job
+from flux.job import JobspecV1
+
+if len(sys.argv) != 2:
+    njobs = 10
+else:
+    njobs = int(sys.argv[1])
+
+# open connection to broker
+h = flux.Flux()
+
+# create jobspec for compute.py
+compute_jobspec = JobspecV1.from_command(
+    command=["./compute.py", "10"], num_tasks=4, num_nodes=2, cores_per_task=2
+)
+compute_jobspec.cwd = os.getcwd()
+compute_jobspec.environment = dict(os.environ)
+
+# create bad jobspec that will fail
+bad_jobspec = JobspecV1.from_command(["/bin/false"])
+
+jobs = []
+flags = flux.constants.FLUX_JOB_WAITABLE
+
+# submit jobs
+for i in range(njobs):
+    if i < njobs / 2:
+        jobid = flux.job.submit(h, compute_jobspec, flags=flags)
+        print("submit: {} compute_jobspec".format(jobid))
+    else:
+        jobid = flux.job.submit(h, bad_jobspec, flags=flags)
+        print("submit: {} bad_jobspec".format(jobid))
+    jobs.append(jobid)
+
+# wait for each job to complete
+for jobid in jobs:
+    result = job.wait(h)
+    if result.success:
+        print("wait: {} Success".format(result.jobid))
+    else:
+        print("wait: {} Error: {}".format(result.jobid, result.errstr))
+
+# vim: tabstop=4 shiftwidth=4 expandtab

--- a/example10/submitter_wait_in_order.py
+++ b/example10/submitter_wait_in_order.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python
+
+import flux
+import sys
+import os
+
+from flux import job
+from flux.job import JobspecV1
+
+if len(sys.argv) != 2:
+    njobs = 10
+else:
+    njobs = int(sys.argv[1])
+
+# open connection to broker
+h = flux.Flux()
+
+# create jobspec for compute.py
+compute_jobspec = JobspecV1.from_command(
+    command=["./compute.py", "10"], num_tasks=4, num_nodes=2, cores_per_task=2
+)
+compute_jobspec.cwd = os.getcwd()
+compute_jobspec.environment = dict(os.environ)
+
+# create bad jobspec that will fail
+bad_jobspec = JobspecV1.from_command(["/bin/false"])
+
+jobs = []
+flags = flux.constants.FLUX_JOB_WAITABLE
+
+# submit jobs
+for i in range(njobs):
+    if i < njobs / 2:
+        jobid = flux.job.submit(h, compute_jobspec, flags=flags)
+        print("submit: {} compute.py".format(jobid))
+    else:
+        jobid = job.submit(h, bad_jobspec, flags=flags)
+        print("submit: {} bad_jobspec".format(jobid))
+    jobs.append(jobid)
+
+# wait for each job in turn by jobid
+for jobid in jobs:
+    result = job.wait(h, jobid)
+    if result.success:
+        print("wait: {} Success".format(result.jobid))
+    else:
+        print("wait: {} Error: {}".format(result.jobid, result.errstr))
+
+# vim: tabstop=4 shiftwidth=4 expandtab


### PR DESCRIPTION
This PR looks to add a new example to our workflow-examples repo based on the idea proposed by @garlick in Issue #45. This example contains three parts:

- **submitter_wait_any.py**: job submit/wait for completion in any order

- **submitter_sliding_window.py**: job submit/wait and keep at most a number of jobs active

- **submitter_by_id.py**: job submit/wait for completion in order by jobid

The **submitter** scripts were essentially copy-and-paste from the examples @garlick provided, which can be found here: [waitany](https://github.com/flux-framework/flux-core/blob/master/t/job-manager/submit-waitany.py), [sliding_window](https://github.com/flux-framework/flux-core/blob/master/t/job-manager/submit-sliding-window.py), and [by_id](https://github.com/flux-framework/flux-core/blob/master/t/job-manager/submit-wait.py). The job I used for submission is **compute.py**, a simple Python script used elsewhere in the repo, like [example2](https://github.com/cmoussa1/flux-workflow-examples/tree/example10/example2). 

Since this example already exist in our repo, I didn't include its link in the top-level README. If this gets merged, I'll create a tiny PR that includes its link in `master`. 