### PR TITLE
top-level README: remove "Lua" from example 2 description

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ separate nodes using the CLI
 
 **_2. [Use a Direct job.submit RPC](https://github.com/flux-framework/flux-workflow-examples/tree/master/example2)_**
 
-Schedule/launch compute and io-forwarding jobs on separate nodes using the Lua and Python bindings
+Schedule/launch compute and io-forwarding jobs on separate nodes using the Python bindings
 
 **_3. [Use Events](https://github.com/flux-framework/flux-workflow-examples/tree/master/example3)_**
 


### PR DESCRIPTION
This tiny PR removes "Lua" from _example2_'s description in the top-level **README.md** since the Lua bindings have been deprecated. 
