### PR TITLE
misc: update shebang to python3, fix example8 README

### DIFF
--- a/example1/compute.py
+++ b/example1/compute.py
@@ -1,14 +1,17 @@
-#!/bin/env python
+#!/usr/bin/env python3
 
 import argparse
 import time
 
-parser = argparse.ArgumentParser (description='compute for seconds')
-parser.add_argument ('integer', metavar='S', type=int,
-                     help='an integer for the number of seconds to compute')
+parser = argparse.ArgumentParser(description="compute for seconds")
+parser.add_argument(
+    "integer",
+    metavar="S",
+    type=int,
+    help="an integer for the number of seconds to compute",
+)
 
-args = parser.parse_args ()
+args = parser.parse_args()
 
-print "Will compute for " + str (args.integer) + " seconds."
-time.sleep (args.integer)
-
+print("Will compute for " + str(args.integer) + " seconds.")
+time.sleep(args.integer)

--- a/example1/io-forwarding.py
+++ b/example1/io-forwarding.py
@@ -1,14 +1,17 @@
-#!/bin/env python
+#!/usr/bin/env python3
 
 import argparse
 import time
 
-parser = argparse.ArgumentParser (description='forward I/O requests for seconds')
-parser.add_argument ('integer', metavar='S', type=int,
-                     help='an integer for the number of seconds to compute')
+parser = argparse.ArgumentParser(description="forward I/O requests for seconds")
+parser.add_argument(
+    "integer",
+    metavar="S",
+    type=int,
+    help="an integer for the number of seconds to compute",
+)
 
-args = parser.parse_args ()
+args = parser.parse_args()
 
-print "Will forward I/O requests for " + str (args.integer) + " seconds."
-time.sleep (args.integer)
-
+print("Will forward I/O requests for " + str(args.integer) + " seconds.")
+time.sleep(args.integer)

--- a/example10/compute.py
+++ b/example10/compute.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import argparse
 import time
@@ -13,5 +13,5 @@ parser.add_argument(
 
 args = parser.parse_args()
 
-print "Will compute for " + str(args.integer) + " seconds."
+print ("Will compute for " + str(args.integer) + " seconds.")
 time.sleep(args.integer)

--- a/example10/submitter_sliding_window.py
+++ b/example10/submitter_sliding_window.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import flux
 import sys

--- a/example10/submitter_wait_any.py
+++ b/example10/submitter_wait_any.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import json
 import os

--- a/example10/submitter_wait_in_order.py
+++ b/example10/submitter_wait_in_order.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import flux
 import sys

--- a/example2/compute.py
+++ b/example2/compute.py
@@ -1,4 +1,4 @@
-#!/bin/env python
+#!/usr/bin/env python3
 
 import argparse
 import time
@@ -13,5 +13,5 @@ parser.add_argument(
 
 args = parser.parse_args()
 
-print "Will compute for " + str(args.integer) + " seconds."
+print("Will compute for " + str(args.integer) + " seconds.")
 time.sleep(args.integer)

--- a/example2/io-forwarding.py
+++ b/example2/io-forwarding.py
@@ -1,4 +1,4 @@
-#!/bin/env python
+#!/usr/bin/env python3
 
 import argparse
 import time
@@ -13,5 +13,5 @@ parser.add_argument(
 
 args = parser.parse_args()
 
-print "Will forward I/O requests for " + str(args.integer) + " seconds."
+print("Will forward I/O requests for " + str(args.integer) + " seconds.")
 time.sleep(args.integer)

--- a/example2/submitter.py
+++ b/example2/submitter.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import json
 import os

--- a/example2/submitter2.py
+++ b/example2/submitter2.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import json
 import os

--- a/example7/bookkeeper.py
+++ b/example7/bookkeeper.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import json
 import os

--- a/example7/compute.py
+++ b/example7/compute.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import argparse
 import time

--- a/example7/io-forwarding.py
+++ b/example7/io-forwarding.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import argparse
 import time

--- a/example8/README.md
+++ b/example8/README.md
@@ -1,4 +1,4 @@
-### Example 9 - KVS Python Binding Example
+### Example 8 - KVS Python Binding Example
 
 #### Description: Use the KVS Python interface to store user data into KVS
 
@@ -8,7 +8,7 @@
 
 2. Submit the Python script:
 
-`flux submit -N 1 -n 1 ./kvsput-usrdata.py`
+`flux mini submit -N 1 -n 1 ./kvsput-usrdata.py`
 
 ```
 6705031151616

--- a/example8/kvsput-usrdata.py
+++ b/example8/kvsput-usrdata.py
@@ -1,24 +1,24 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import sys
 import flux
 import os
 from flux import kvs
 
-f = flux.Flux ()
+f = flux.Flux()
 udata = "hello world"
 # using function interface
-kvs.put (f, "usrdata", udata)
+kvs.put(f, "usrdata", udata)
 # commit is required to effect the above put op to the server
-kvs.commit (f)
-print kvs.get (f, "usrdata")
+kvs.commit(f)
+print(kvs.get(f, "usrdata"))
 
 # get() on a directory will return a KVSDir object which supports
 # the "with" compound statement. "with" guarantees a commit is called
 # on the directory.
-with kvs.get (f, ".") as kd:
-   kd['usrdata2'] = "hello world again"
+with kvs.get(f, ".") as kd:
+    kd["usrdata2"] = "hello world again"
 
-print kvs.get (f, "usrdata2")
+print(kvs.get(f, "usrdata2"))
 
 # vi: ts=4 sw=4 expandtab

--- a/example9/compute.py
+++ b/example9/compute.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import argparse
 import time

--- a/example9/datastore.py
+++ b/example9/datastore.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import socket
 import struct
@@ -6,54 +6,63 @@ import json
 import sys
 import os
 
-sockdir = os.path.join("/tmp", os.environ['USER'])
+sockdir = os.path.join("/tmp", os.environ["USER"])
 sockname = os.path.join(sockdir, "mysock")
 
 store = {}
 sock = ""
 
-def initialize ():
+
+def initialize():
     global sock
     if not os.path.exists(sockdir):
         os.mkdir(sockdir)
-    if os.path.exists (sockname):
-        os.remove (sockname)
-    sock = socket.socket (socket.AF_UNIX, socket.SOCK_STREAM)
-    sock.bind (sockname)
-    sock.listen (1)
+    if os.path.exists(sockname):
+        os.remove(sockname)
+    sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    sock.bind(sockname)
+    sock.listen(1)
     cmd = "flux module load ./conduit.so"
-    os.system (cmd)
+    os.system(cmd)
 
-def run ():
+
+def run():
     global sock
     global store
     connection, client_address = sock.accept()
-    for x in range (5):
-       print "Waiting for a packet"
-       mybytes = bytearray (4)
-       nbytes, address = connection.recvfrom_into (mybytes, 4)
-       if nbytes == 0:
-            break;
-       size = mybytes[0]*1 + mybytes[1]*256 + mybytes[2]*65536 + mybytes[3]*16777216
-       data = bytearray (size)
-       nbytes, address = connection.recvfrom_into (data, size)
-       dict_blob = json.loads (data.decode ("ascii"))
+    for x in range(5):
+        print("Waiting for a packet")
+        mybytes = bytearray(4)
+        nbytes, address = connection.recvfrom_into(mybytes, 4)
+        if nbytes == 0:
+            break
+        size = (
+            mybytes[0] * 1
+            + mybytes[1] * 256
+            + mybytes[2] * 65536
+            + mybytes[3] * 16777216
+        )
+        data = bytearray(size)
+        nbytes, address = connection.recvfrom_into(data, size)
+        dict_blob = json.loads(data.decode("ascii"))
 
-       if dict_blob is not None:
-           store.update (dict_blob)
-           print store
-       else:
-           print "Mallformed data, discarding"
+        if dict_blob is not None:
+            store.update(dict_blob)
+            print(store)
+        else:
+            print("Mallformed data, discarding")
 
-    connection.close ()
+    connection.close()
     cmd = "flux module remove conduit"
-    os.system (cmd)
-    print "Bye bye!"
+    os.system(cmd)
+    print("Bye bye!")
 
-def main ():
-    print "Starting...."
-    initialize ()
-    run ()
+
+def main():
+    print("Starting....")
+    initialize()
+    run()
+
 
 if __name__ == "__main__":
-    main ()
+    main()


### PR DESCRIPTION
This PR makes the following changes:

- update shebang to use python3 instead of python2
- blacken Python files in examples

It also makes a small correction in example8 which I failed to realize a couple of PR's ago:
- change the title number of example8's **README** from example 9 to example 8
- change `flux submit` instruction to `flux mini submit`
