### PR TITLE
example7: update semantics of command line args, update README

### DIFF
--- a/example7/README.md
+++ b/example7/README.md
@@ -10,32 +10,25 @@
 
 `srun --pty --mpi=none -N3 flux start -o,-S,log-filename=out`
 
-3. Run the bookkeeper executable:
+3. Run the bookkeeper executable along with the number of jobs to be submitted (if no size is specified, 6 jobs are submitted: 3 instances of **compute.py**, and 3 instances of **io-forwarding,py**):
 
-`./bookkeeper.py 5`
+`./bookkeeper.py 2`
 
 ```
+17341081452544
+17341383442432
 bookkeeper: all jobs submitted
 bookkeeper: waiting until all jobs complete
-job 1417322430464 changed its state to DEPEND
-job 1417322430464 changed its state to SCHED
-job 1417758638080 changed its state to DEPEND
-job 1417758638080 changed its state to SCHED
-job 1418161291264 changed its state to DEPEND
-job 1418161291264 changed its state to SCHED
-.
-.
-.
-job 282058555392 changed its state to CLEANUP
-job 285564993536 changed its state to CLEANUP
-.
-.
-.
-job 282058555392 changed its state to INACTIVE
-job 285564993536 changed its state to INACTIVE
-.
-.
-.
+job 17341081452544 changed its state to DEPEND
+job 17341081452544 changed its state to SCHED
+job 17341081452544 changed its state to RUN
+job 17341383442432 changed its state to DEPEND
+job 17341383442432 changed its state to SCHED
+job 17341081452544 changed its state to CLEANUP
+job 17341081452544 changed its state to INACTIVE
+job 17341383442432 changed its state to RUN
+job 17341383442432 changed its state to CLEANUP
+job 17341383442432 changed its state to INACTIVE
 bookkeeper: all jobs completed
 ```
 
@@ -49,7 +42,7 @@ bookkeeper: all jobs completed
 - The following constructs a job request using the **JobspecV1** class with customizable parameters for how you want to utilize the resources allocated for your job:
 ```python
 compute_jobreq = JobspecV1.from_command(
-    command=["./compute.py", "120"], num_tasks=4, num_nodes=2, cores_per_task=2
+    command=["./compute.py", "10"], num_tasks=4, num_nodes=2, cores_per_task=2
 )
 compute_jobreq.cwd = os.getcwd()
 compute_jobreq.environment = dict(os.environ)
@@ -59,10 +52,10 @@ compute_jobreq.environment = dict(os.environ)
 
 - Throughout the course of a job, its state will go through a number of changes. The following subscribes to the event messages matching the transition of those states in the jobs submitted.
 ```python
-f.event_subscribe("job-state")
-f.msg_watcher_create(job_state_cb, 0, "job-state").start()
-submit_bundles(f, args.integer)
-print("bookkeeper: waiting until all jobs complete)
-f.reactor_run(f.get_reactor(), 0)
-print("bookkeeper: all jobs completed")
+    f.event_subscribe("job-state")
+    f.msg_watcher_create(job_state_cb, 0, "job-state").start()
+    submit_bundles(f, njobs)
+    print("bookkeeper: waiting until all jobs complete")
+    f.reactor_run(f.get_reactor(), 0)
+    print("bookkeeper: all jobs completed")
 ```

--- a/example7/bookkeeper.py
+++ b/example7/bookkeeper.py
@@ -2,28 +2,29 @@
 
 import json
 import os
-import flux
 import argparse
+import sys
+
+import flux
+from flux.job import JobspecV1
 
 compute_jobreq = JobspecV1.from_command(
-    command=["./compute.py", "120"], num_tasks=6, num_nodes=3, cores_per_task=2
+    command=["./compute.py", "10"], num_tasks=6, num_nodes=3, cores_per_task=2
 )
 compute_jobreq.cwd = os.getcwd()
 compute_jobreq.environment = dict(os.environ)
 
 io_jobreq = JobspecV1.from_command(
-    command=["./io-forwarding.py", "120"], num_tasks=3, num_nodes=3, cores_per_task=1
+    command=["./io-forwarding.py", "10"], num_tasks=3, num_nodes=3, cores_per_task=1
 )
 io_jobreq.cwd = os.getcwd()
 io_jobreq.environment = dict(os.environ)
 
-njobs = 0
-
 
 def job_state_cb(f, typemask, message, arg):
     global njobs
-    N = args.integer
-    for jobid, state in message.payload["transitions"]:
+    N = njobs
+    for jobid, state, time in message.payload["transitions"]:
         print("job " + str(jobid) + " changed its state to " + str(state))
         if state == "INACTIVE":
             njobs += 1
@@ -33,10 +34,11 @@ def job_state_cb(f, typemask, message, arg):
 
 # submit bundles of jobs using flux.job.submit ()
 def submit_bundles(f, N):
-    f = flux.Flux()
-    for i in range(0, N):
+    for i in range(0, N // 2):
         print(flux.job.submit(f, compute_jobreq))
         print(flux.job.submit(f, io_jobreq))
+    if N % 2 == 1:
+        print(flux.job.submit(f, compute_jobreq))
 
     print("bookkeeper: all jobs submitted")
 
@@ -54,13 +56,16 @@ def main():
         type=int,
         help="the number of bundles to submit and wait",
     )
-    global args
-    args = parser.parse_args()
+
+    if len(sys.argv) != 2:
+        njobs = 6
+    else:
+        njobs = int(sys.argv[1])
 
     f = flux.Flux()
     f.event_subscribe("job-state")
     f.msg_watcher_create(job_state_cb, 0, "job-state").start()
-    submit_bundles(f, args.integer)
+    submit_bundles(f, njobs)
     print("bookkeeper: waiting until all jobs complete")
     f.reactor_run(f.get_reactor(), 0)
     print("bookkeeper: all jobs completed")


### PR DESCRIPTION
This PR addresses issue #59 and updates the semantics of the command line argument in **bookkeeper.py**. When a job bundle number _x_ is specified, _x_ instances of **compute.py** and _x_ instances of **io-forwarding.py** are submitted. If no argument is passed, than 10 jobs (5 of each) are submitted. That note is also made in **README.md**:

> 3. Run the bookkeeper executable along with the size of the jobs bundle (if no size is specified, 5 instances of **compute.py** and 5 instances of **io-forwarding,py** jobs are submitted):