### PR TITLE
example10: change args in job.submit

### DIFF
--- a/job-submit-wait/README.md
+++ b/job-submit-wait/README.md
@@ -134,6 +134,6 @@ compute_jobspec.cwd = os.getcwd()
 compute_jobspec.environment = dict(os.environ)
 ```
 
-- `flux.job.submit(h, compute_jobspec, flags=flags)` submits the job to be run, and returns a job ID once it begins running.
+- `flux.job.submit(h, compute_jobspec, waitable=True)` submits the job to be run, and returns a job ID once it begins running.
 
 - `result = job.wait(h, jobid)` waits for a job to transition to the **INACTIVE** state, then returns a summary of the job result, either a **Success** or an **Error** string.

--- a/job-submit-wait/submitter_sliding_window.py
+++ b/job-submit-wait/submitter_sliding_window.py
@@ -24,14 +24,13 @@ compute_jobspec = JobspecV1.from_command(
 compute_jobspec.cwd = os.getcwd()
 compute_jobspec.environment = dict(os.environ)
 
-flags = flux.constants.FLUX_JOB_WAITABLE
 done = 0
 running = 0
 
 # submit jobs, keep [window_size] jobs running
 while done < njobs:
     if running < window_size and done + running < njobs:
-        jobid = flux.job.submit(h, compute_jobspec, flags=flags)
+        jobid = flux.job.submit(h, compute_jobspec, waitable=True)
         print("submit: {}".format(jobid))
         running += 1
 

--- a/job-submit-wait/submitter_wait_any.py
+++ b/job-submit-wait/submitter_wait_any.py
@@ -27,15 +27,14 @@ compute_jobspec.environment = dict(os.environ)
 bad_jobspec = JobspecV1.from_command(["/bin/false"])
 
 jobs = []
-flags = flux.constants.FLUX_JOB_WAITABLE
 
 # submit jobs
 for i in range(njobs):
     if i < njobs / 2:
-        jobid = flux.job.submit(h, compute_jobspec, flags=flags)
+        jobid = flux.job.submit(h, compute_jobspec, waitable=True)
         print("submit: {} compute_jobspec".format(jobid))
     else:
-        jobid = flux.job.submit(h, bad_jobspec, flags=flags)
+        jobid = flux.job.submit(h, bad_jobspec, waitable=True)
         print("submit: {} bad_jobspec".format(jobid))
     jobs.append(jobid)
 

--- a/job-submit-wait/submitter_wait_in_order.py
+++ b/job-submit-wait/submitter_wait_in_order.py
@@ -26,15 +26,14 @@ compute_jobspec.environment = dict(os.environ)
 bad_jobspec = JobspecV1.from_command(["/bin/false"])
 
 jobs = []
-flags = flux.constants.FLUX_JOB_WAITABLE
 
 # submit jobs
 for i in range(njobs):
     if i < njobs / 2:
-        jobid = flux.job.submit(h, compute_jobspec, flags=flags)
+        jobid = flux.job.submit(h, compute_jobspec, waitable=True)
         print("submit: {} compute.py".format(jobid))
     else:
-        jobid = job.submit(h, bad_jobspec, flags=flags)
+        jobid = job.submit(h, bad_jobspec, waitable=True)
         print("submit: {} bad_jobspec".format(jobid))
     jobs.append(jobid)
 


### PR DESCRIPTION
In response to `flux-framework`'s recent PR [#2719](https://github.com/flux-framework/flux-core/pull/2719), example10 needs to change its parameters when using `job.submit`. This PR changes the args in `job.submit` and replaces `flags` with `waitable=True`. 
