### PR TITLE
async-bulk-job-submit: update bulksubmit.py

### DIFF
--- a/async-bulk-job-submit/README.md
+++ b/async-bulk-job-submit/README.md
@@ -38,12 +38,12 @@ bulksubmit: Ran 1025 jobs in 34.9s. 29.4 job/s
 
 - `h = flux.Flux()` creates a new Flux handle which can be used to connect to and interact with a Flux instance.
 
-- `job_submit_async(h, jobspec.read(), flags=flags).then(submit_cb)` submits a jobspec, returning a future which will be fulfilled when the submission of this job is complete.
+- `job_submit_async(h, jobspec.read(), waitable=True).then(submit_cb)` submits a jobspec, returning a future which will be fulfilled when the submission of this job is complete.
 
 `.then(submit_cb)`, called on the returned future, will cause our callback `submit_cb()` to be invoked when the submission of this job is complete and a jobid is available. To process job submission RPC responses and invoke callabacks, the flux reactor for handle `h` must be run:
 
 ```python
-if h.reactor_run(h.get_reactor(), 0) < 0:
+if h.reactor_run() < 0:
 ￼    h.fatal_error("reactor start failed")
 ```
 

--- a/async-bulk-job-submit/bulksubmit.py
+++ b/async-bulk-job-submit/bulksubmit.py
@@ -8,7 +8,6 @@ from flux import job
 from flux import constants
 
 t0 = time.time()
-flags = flux.constants.FLUX_JOB_WAITABLE
 jobs = []
 label = "bulksubmit"
 
@@ -37,9 +36,9 @@ def submit_cb(f, arg):
 log("Starting...")
 for file in sys.argv[1:]:
     with open(file) as jobspec:
-        job.submit_async(h, jobspec.read(), flags=flags).then(submit_cb)
+        job.submit_async(h, jobspec.read(), waitable=True).then(submit_cb)
 
-if h.reactor_run(h.get_reactor(), 0) < 0:
+if h.reactor_run() < 0:
     h.fatal_error("reactor start failed")
 
 total = len(jobs)


### PR DESCRIPTION
Mentioned in #66: **bulksubmit.py** needed to be updated. This PR replaces the `flags` parameter in `job.submit_async` with `waitable=True`. 

@dongahn you had also mentioned in your [comment](https://github.com/flux-framework/flux-core/issues/2915#issuecomment-620889771) that you commented out the `sys.stdout.write(s)` line; however I believe that line just prints out the progress bar, right? I tested it with the current version of flux-core and it seemed to work just fine. If you still want it removed, just let me know and I'd be happy to remove it. 
