### PR TITLE
repo: add mergify, Github actions to repository 

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,33 @@
+# This workflow will install Python dependencies, run tests and lint with a variety of Python versions
+# For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
+
+on: [pull_request]
+jobs:
+  check-pr:
+    name: check formatting
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        python-version: [3.6, 3.7, 3.8]
+
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        ref: ${{ github.event.pull_request.head.sha }}
+        fetch-depth: 0
+    - run: git fetch origin master
+    - uses: flux-framework/pr-validator@master
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v1
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Lint with flake8
+      run: |
+        pip install flake8
+        pip install black
+        # stop the build if there are Python syntax errors or undefined names
+        flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+        # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
+        flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+        black .

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,0 +1,16 @@
+pull_request_rules:
+  - name: rebase and merge when passing all checks
+    conditions:
+      - base=master
+      - label="merge-when-passing"
+      - label!="work-in-progress"
+      - "approved-reviews-by=@flux-framework/core"
+      - "#approved-reviews-by>0"
+      - "#changes-requested-reviews-by=0"
+      - -title~=^\[*[Ww][Ii][Pp]
+      - status-success="check formatting"
+    actions:
+      merge:
+        method: merge
+        strict: smart
+        strict_method: rebase


### PR DESCRIPTION
This PR adds mergify and Github actions to the repository so that PR's can automatically be merged. The Github Actions file is pulled from the other flux-framework projects, and **.mergify.yml** is pulled from flux-accounting (without the status check for Python versions, since not all examples are exclusively Python). I believe the `black` and `flake8` Python-specific actions should exit safely regardless of whether there is Python code present or not. 

The .mergify.yml file is pretty barebones right now, but I'm not sure if there are additional checks we would want to perform on a new/edited example in this repository. 

Fixes #71 