### PR TITLE
flux jobs: update examples to use 'flux jobs' instead of 'flux job list

### DIFF
--- a/job-submit-api/README.md
+++ b/job-submit-api/README.md
@@ -16,26 +16,26 @@
 
 4. List currently running jobs:
 
-`flux job list`
+`flux jobs`
 
 ```
-JOBID		STATE	USERID	PRI	NAME		T_SUBMIT
-316703506432	R	58985	16	./io-forwarding	2019-12-16T21:54:19Z
-316250521600	R	58985	16	./compute.py   	2019-12-16T21:54:19Z
+JOBID    USER     NAME       ST NTASKS NNODES  RUNTIME RANKS
+ƒ5W8gVwm moussa1  io-forward  R      1      1   19.15s 2
+ƒ5Vd2kJs moussa1  compute.py  R      4      2   19.18s [0-1]
 ```
 
 5. Information about jobs, such as the submitted job specification, an eventlog, and the resource description format **R** are stored in the KVS. The data can be queried via the `job-info` module via the `flux job info` command. For example, to fetch **R** for a job which has been allocated resources:
 
-`flux job info 316703506432 R`
-
-```
-{"version":1,"execution":{"R_lite":[{"rank":"0-1","children":{"core":"0-3"}}]}}
-```
-
-`flux job info 316250521600 R`
+`flux job info ƒ5W8gVwm R`
 
 ```
 {"version":1,"execution":{"R_lite":[{"rank":"2","children":{"core":"0"}}]}}
+```
+
+`flux job info ƒ5Vd2kJs R`
+
+```
+{"version":1,"execution":{"R_lite":[{"rank":"0-1","children":{"core":"0-3"}}]}}
 ```
 
 ### Part(b) - Using a direct job.submit RPC
@@ -56,23 +56,23 @@ JOBID		STATE	USERID	PRI	NAME		T_SUBMIT
 
 4. List currently running jobs:
 
-`flux job list`
+`flux jobs`
 
 ```
-JOBID		STATE	USERID	PRI	NAME		T_SUBMIT
-266187309056	R	58985	16	./io-forwarding	2019-12-16T22:01:59Z
-265767878656	R	58985	16	./compute.py   	2019-12-16T22:01:59Z
+JOBID    USER     NAME       ST NTASKS NNODES  RUNTIME RANKS
+ƒctYadhh moussa1  io-forward  R      3      3   3.058s [0-2]
+ƒct1StnT moussa1  compute.py  R      6      3   3.086s [0-2]
 ```
 
 5. Fetch **R** for the jobs that have been allocated resources:
 
-`flux job info 266187309056 R`
+`flux job info ƒctYadhh R`
 
 ```
-{"version":1,"execution":{"R_lite":[{"rank":"0-2","children":{"core":"4"}}]}}
+{"version":1,"execution":{"R_lite":[{"rank":"0-2","children":{"core":"0-3"}}]}}
 ```
 
-`flux job info 265767878656 R`
+`flux job info ƒct1StnT R`
 
 ```
 {"version":1,"execution":{"R_lite":[{"rank":"0-2","children":{"core":"0-3"}}]}}

--- a/job-submit-cli/README.md
+++ b/job-submit-cli/README.md
@@ -12,26 +12,26 @@
 
 5. List running jobs:
 
-`flux job list`
+`flux jobs`
 
 ```  
-JOBID		       STATE	  USERID   PRI     T_SUBMIT
-640671547392	   R	      58985	   16	   2019-10-22T16:27:02Z
-1045388328960	   R	      58985	   16	   2019-10-22T16:27:26Z
+JOBID     USER     NAME       ST NTASKS NNODES  RUNTIME RANKS
+ƒ3ETxsR9H moussa1  io-forward  R      1      1   2.858s 2
+ƒ38rBqEWT moussa1  compute.lu  R      4      2    15.6s [0-1]
 ```
 
 6. Get information about job:
 
-`flux job info 640671547392 R`
-
-```
-{"version":1,"execution":{"R_lite":[{"rank":"0-1","children":{"core":"0-3"}}]}}
-```
-
-`flux job info 1045388328960 R`
+`flux job info ƒ3ETxsR9H R`
 
 ```
 {"version":1,"execution":{"R_lite":[{"rank":"2","children":{"core":"0-1"}}]}}
+```
+
+`flux job info ƒ38rBqEWT R`
+
+```
+{"version":1,"execution":{"R_lite":[{"rank":"0-1","children":{"core":"0-3"}}]}}
 ```
 
 ### Part(b) - Overlapping Schedule
@@ -48,25 +48,25 @@ JOBID		       STATE	  USERID   PRI     T_SUBMIT
 
 5. List jobs in KVS:
 
-`flux job list`
+`flux jobs`
 
 ```
-JOBID		       STATE	  USERID   PRI     T_SUBMIT
-2098158632960	   R	      58985	   16	   2019-10-22T16:35:25Z
-2331043168256	   R	      58985	   16	   2019-10-22T16:35:39Z
+JOBID     USER     NAME       ST NTASKS NNODES  RUNTIME RANKS
+ƒ3ghmgCpw moussa1  io-forward  R      3      3   16.91s [0-2]
+ƒ3dSybfQ3 moussa1  compute.lu  R      6      3    24.3s [0-2]
 
 ```
 
 6. Get information about job:
 
-`flux job info 2098158632960 R`
+`flux job info ƒ3ghmgCpw R`
 
 ```
-{"version":1,"execution":{"R_lite":[{"rank":"2","children":{"core":"2-5"}},{"rank":"0-1","children":{"core":"4-7"}}]}}
+{"version":1,"execution":{"R_lite":[{"rank":"0-2","children":{"core":"4"}}]}}
 ```
 
-`flux job info 2331043168256 R`
+`flux job info ƒ3dSybfQ3 R`
 
 ```
-{"version":1,"execution":{"R_lite":[{"rank":"2","children":{"core":"6-7"}},{"rank":"0","children":{"core":"8"}}]}}
+{"version":1,"execution":{"R_lite":[{"rank":"0-2","children":{"core":"0-3"}}]}}
 ```

--- a/synchronize-events/README.md
+++ b/synchronize-events/README.md
@@ -8,25 +8,25 @@
 
 3. `flux mini submit --nodes=2 --ntasks=4 --cores-per-task=2 ./compute.lua 120`
 
-**Output -** `901355929600`
+**Output -** `225284456448`
 
-4. `flux submit --nnodes=1 --ntasks=1 --cores-per-task=2 ./io-forwarding.lua 120`
+4. `flux mini submit --nodes=1 --ntasks=1 --cores-per-task=2 ./io-forwarding.lua 120`
 
-**Output -** `1244299001856`
+**Output -** `344889229312`
 
 5. List running jobs:
 
-`flux job list`
+`flux jobs`
 
 ```
-JOBID		       STATE	  USERID   PRI     T_SUBMIT
-901355929600	   R	      58985	   16	   2019-10-22T16:27:02Z
-1244299001856	   R	      58985	   16	   2019-10-22T16:27:26Z
+JOBID    USER     NAME       ST NTASKS NNODES  RUNTIME RANKS
+ƒA4TgT7d moussa1  io-forward  R      1      1   4.376s 2
+ƒ6vEcj7M moussa1  compute.lu  R      4      2   11.51s [0-1]
 ```
 
 6. Attach to running or completed job output:
 
-`flux job attach 901355929600`
+`flux job attach ƒ6vEcj7M`
 
 ```
 Block until we hear go message from the an io forwarder


### PR DESCRIPTION
**Problem:** As noted in #74, some of the examples are still using `flux job list`.

This PR updates the command to `flux jobs` in a a number of the examples. 

Fixes #74 