### PR TITLE
Add a job-cancel example

### DIFF
--- a/job-cancel/README.md
+++ b/job-cancel/README.md
@@ -1,0 +1,32 @@
+### Job Cancellation
+
+#### Description: Cancel a running job
+
+1. Launch the submitter script:
+
+`./submitter.py $(flux resource list -no {ncores} --state=up)`
+
+_note: for older versions of Flux, you might need to instead run: `./submitter.py $(flux hwloc info | awk '{print $3}')`_
+
+```
+Submitted 1st job: 2241905819648
+Submitted 2nd job: 2258951471104
+
+First submitted job status (2241905819648) - RUNNING
+Second submitted job status (2258951471104) - PENDING
+
+Cancelled first job: 2241905819648
+
+First submitted job status (2241905819648) - CANCELLED
+Second submitted job status (2258951471104) - RUNNING
+```
+
+##### Notes
+
+- `f = flux.Flux()` creates a new Flux handle which can be used to connect to and interact with a Flux instance.
+
+- `flux.job.submit(f, sleep_jobspec, waitable=True)` submits a jobspec, returning a job ID that can be used to interact with the submitted job.
+
+- `flux.job.cancel(f, jobid)` cancels the job.
+
+- `flux.job.wait_async(f, jobid)` will wait for the job to complete (or in this case, be cancelled). It returns a Flux future, which can be used to process the result later. Only jobs submitted with `waitable=True` can be waited for.

--- a/job-cancel/submitter.py
+++ b/job-cancel/submitter.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+
+import time
+import argparse
+
+import flux
+from flux.job import JobspecV1
+
+f = flux.Flux()
+
+parser = argparse.ArgumentParser(
+    description="""
+    Description: Submit two 'sleep 60' jobs that take up
+    all resources on a node.
+    """
+)
+parser.add_argument(dest="cores", help="number of cores on the node")
+args = parser.parse_args()
+
+# submit a sleep job that takes up all resources
+sleep_jobspec = JobspecV1.from_command(
+    ["sleep", "60"], num_tasks=1, cores_per_task=int(args.cores)
+)
+first_jobid = flux.job.submit(f, sleep_jobspec, waitable=True)
+print("Submitted 1st job: %d" % (int(first_jobid)))
+time.sleep(1)
+
+# submit a second sleep job - will be scheduled, but not run
+sleep_jobspec = JobspecV1.from_command(
+    ["sleep", "60"], num_tasks=1, cores_per_task=int(args.cores)
+)
+second_jobid = flux.job.submit(f, sleep_jobspec, waitable=True)
+print("Submitted 2nd job: %d\n" % (int(second_jobid)))
+time.sleep(1)
+
+# get list of JobInfo objects - fetch their ID's and current status
+jobs = flux.job.JobList(f, max_entries=2).jobs()
+print("First submitted job status (%d) - %s" % (int(jobs[1].id.dec), jobs[1].status))
+print("Second submitted job status (%d) - %s\n" % (int(jobs[0].id.dec), jobs[0].status))
+
+# cancel the first job
+flux.job.cancel(f, first_jobid)
+future = flux.job.wait_async(f, first_jobid).wait_for(5.0)
+return_id, success, errmsg = future.get_status()
+print("Cancelled first job: %d\n" % (int(return_id)))
+time.sleep(1)
+
+# the second job should now run since the first was cancelled
+jobs = flux.job.JobList(f, max_entries=2).jobs()
+print("First submitted job status (%d) - %s" % (int(jobs[1].id.dec), jobs[1].status))
+print("Second submitted job status (%d) - %s" % (int(jobs[0].id.dec), jobs[0].status))


### PR DESCRIPTION
This PR adds a new workflow example to demonstrate Flux's `job cancel` Python binding. It consists of one script that submits a `sleep 180` job, cancels it, and lists the job id after.

For now, the output from `submitter.py` just lists the submitted job id, the same ID after it gets cancelled, and the list of job IDs using `flux.job.job_list(flux_handle)`:

```
Submitted job: 10080741228544
Cancelled job: 10080741228544
Job IDs: [{'id': 10080741228544}]
```

I'm trying to think if there is a better way to showcase the `cancel` feature with the Python script? 