### PR TITLE
Add Sphinx and ReadTheDocs Support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,25 @@
+# Minimal makefile for Sphinx documentation
+#
+
+# You can set these variables from the command line, and also
+# from the environment for the first two.
+SPHINXOPTS    ?=
+SPHINXBUILD   ?= sphinx-build
+SOURCEDIR     = .
+BUILDDIR      = _build
+
+# Put it first so that "make" without argument is like "make help".
+help:
+	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+.PHONY: help Makefile check spelling $(SCHEMA_DIRS)
+
+# Catch-all target: route all unknown targets to Sphinx using the new
+# "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
+%: Makefile
+	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+check: spelling
+
+spelling:
+	@$(SPHINXBUILD) -W -b spelling "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/README.md
+++ b/README.md
@@ -21,27 +21,31 @@ Asynchronously submit jobspec files from a directory and wait for them to comple
 
 Submit job bundles and wait until all jobs complete
 
-**_6. [Use Events](https://github.com/flux-framework/flux-workflow-examples/tree/master/synchronize-events)_**
+**_6. [Job Cancellation](https://github.com/flux-framework/flux-workflow-examples/tree/master/job-cancel)_**
+
+Cancel a running job
+
+**_7. [Use Events](https://github.com/flux-framework/flux-workflow-examples/tree/master/synchronize-events)_**
 
 Use events to synchronize compute and io-forwarding jobs running on separate
 nodes
 
-**_7. [Simple KVS Python Binding Example](https://github.com/flux-framework/flux-workflow-examples/tree/master/kvs-python-bindings)_**
+**_8. [Simple KVS Python Binding Example](https://github.com/flux-framework/flux-workflow-examples/tree/master/kvs-python-bindings)_**
 
 Use KVS Python interfaces to store user data into KVS
 
-**_8. [Job Ensemble Submitted with a New Flux Instance](https://github.com/flux-framework/flux-workflow-examples/tree/master/job-ensemble)_**
+**_9. [Job Ensemble Submitted with a New Flux Instance](https://github.com/flux-framework/flux-workflow-examples/tree/master/job-ensemble)_**
 
 Submit job bundles, print live job events, and exit when all jobs are complete
 
-**_9. [Hierarchical Launching](https://github.com/flux-framework/flux-workflow-examples/tree/master/hierarchical-launching)_**
+**_10. [Hierarchical Launching](https://github.com/flux-framework/flux-workflow-examples/tree/master/hierarchical-launching)_**
 
 Launch a large number of sleep 0 jobs
 
-**_10. [Use a Flux Comms Module](https://github.com/flux-framework/flux-workflow-examples/tree/master/comms-module)_**
+**_11. [Use a Flux Comms Module](https://github.com/flux-framework/flux-workflow-examples/tree/master/comms-module)_**
 
 Use a Flux Comms Module to communicate with job elements
 
-**_11. [A Data Conduit Strategy](https://github.com/flux-framework/flux-workflow-examples/tree/master/data-conduit)_**
+**_12. [A Data Conduit Strategy](https://github.com/flux-framework/flux-workflow-examples/tree/master/data-conduit)_**
 
 Attach to a job that receives OS time data from compute jobs

--- a/async-bulk-job-submit/README.md
+++ b/async-bulk-job-submit/README.md
@@ -1,6 +1,6 @@
-### Python Asynchronous Bulk Job Submission
+## Python Asynchronous Bulk Job Submission
 
-#### Description: Asynchronously submit jobspec files from a directory and wait for them to complete in any order
+### Description: Asynchronously submit jobspec files from a directory and wait for them to complete in any order
 
 1. Allocate three nodes from a resource manager:
 
@@ -34,7 +34,7 @@ bulksubmit: First job finished in about 3.089s
 bulksubmit: Ran 1025 jobs in 34.9s. 29.4 job/s
 ```
 
-##### Notes
+### Notes
 
 - `h = flux.Flux()` creates a new Flux handle which can be used to connect to and interact with a Flux instance.
 

--- a/conf.py
+++ b/conf.py
@@ -1,0 +1,83 @@
+###############################################################
+# Copyright 2020 Lawrence Livermore National Security, LLC
+# (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+#
+# This file is part of the Flux resource manager framework.
+# For details, see https://github.com/flux-framework.
+#
+# SPDX-License-Identifier: LGPL-3.0
+###############################################################
+
+# Configuration file for the Sphinx documentation builder.
+#
+# This file only contains a selection of the most common options. For a full
+# list see the documentation:
+# https://www.sphinx-doc.org/en/master/usage/configuration.html
+
+# -- Path setup --------------------------------------------------------------
+
+# If extensions (or modules to document with autodoc) are in another directory,
+# add these directories to sys.path here. If the directory is relative to the
+# documentation root, use os.path.abspath to make it absolute, like shown here.
+#
+# import os
+# import sys
+# sys.path.insert(0, os.path.abspath('.'))
+
+
+# -- Project information -----------------------------------------------------
+
+project = 'Flux'
+copyright = '''Copyright 2020 Lawrence Livermore National Security, LLC and Flux developers.
+
+SPDX-License-Identifier: LGPL-3.0'''
+author = 'This page is maintained by the Flux community.'
+
+# The full version, including alpha/beta/rc tags
+release = '0.1.0'
+
+
+# -- General configuration ---------------------------------------------------
+
+# Add any Sphinx extension module names here, as strings. They can be
+# extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
+# ones.
+extensions = [
+    'sphinx.ext.intersphinx',
+    'sphinxcontrib.spelling',
+    'recommonmark',
+]
+
+# sphinxcontrib.spelling settings
+spelling_word_list_filename = [
+    'spell.en.pws'
+]
+
+# Add any paths that contain templates here, relative to this directory.
+templates_path = ['_templates']
+
+# List of patterns, relative to source directory, that match files and
+# directories to ignore when looking for source files.
+# This pattern also affects html_static_path and html_extra_path.
+exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store', 'README.md']
+
+master_doc = 'index'
+source_suffix = ['.rst', '.md']
+
+# -- Options for HTML output -------------------------------------------------
+
+# The theme to use for HTML and HTML Help pages.  See the documentation for
+# a list of builtin themes.
+#
+html_theme = 'sphinx_rtd_theme'
+
+# Add any paths that contain custom static files (such as style sheets) here,
+# relative to this directory. They are copied after the builtin static files,
+# so a file named "default.css" will overwrite the builtin "default.css".
+html_static_path = [
+]
+
+# -- Options for man output -------------------------------------------------
+
+man_pages = [
+]

--- a/data-conduit/README.md
+++ b/data-conduit/README.md
@@ -1,6 +1,6 @@
-### A Data Conduit Strategy
+## A Data Conduit Strategy
 
-#### Description: Use a data stream to send packets through
+### Description: Use a data stream to send packets through
 
 1. Allocate three nodes from a resource manager:
 
@@ -64,7 +64,7 @@ run finished...
 
 ---
 
-##### Notes
+### Notes
 
 - `f = flux.Flux()` creates a new Flux handle which can be used to connect to and interact with a Flux instance.
 

--- a/hierarchical-launching/README.md
+++ b/hierarchical-launching/README.md
@@ -1,6 +1,6 @@
-### Hierarchical Launching
+## Hierarchical Launching
 
-#### Description: Launch an ensemble of sleep 0 tasks
+### Description: Launch an ensemble of sleep 0 tasks
 
 1. `salloc -N3 -ppdebug`
 
@@ -17,7 +17,8 @@ First Level Done
 Mon Nov 18 15:34:13 PST 2019
 ```
 
-#### Notes
+
+### Notes
 
 - You can increase the number of jobs by increasing `NCORES` in `parent.sh` and
 `NJOBS` in `ensemble.sh`.

--- a/index.rst
+++ b/index.rst
@@ -29,6 +29,11 @@ to complete in any order
 
 Submit job bundles and wait until all jobs complete
 
+:doc:`Job Cancellation <job-cancel/README>`
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Cancel a running job
+
 :doc:`Use Events <synchronize-events/README>`
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -69,6 +74,7 @@ Attach to a job that receives OS time data from compute jobs
    job-submit-wait/README
    async-bulk-job-submit/README
    job-status-control/README
+   job-cancel/README
    synchronize-events/README
    kvs-python-bindings/README
    job-ensemble/README

--- a/index.rst
+++ b/index.rst
@@ -1,0 +1,77 @@
+Flux Workflow Examples
+----------------------
+
+:doc:`Job Submit CLI <job-submit-cli/README>`
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Launch a flux instance and schedule/launch compute and io-forwarding
+jobs on separate nodes using the CLI
+
+:doc:`Job Submit API <job-submit-api/README>`
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Schedule/launch compute and io-forwarding jobs on separate nodes using
+the Python bindings
+
+:doc:`Python Job Submit/Wait <job-submit-wait/README>`
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Submit jobs and wait for them to complete using the Flux Python bindings
+
+:doc:`Python Asynchronous Bulk Job Submission <async-bulk-job-submit/README>`
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Asynchronously submit jobspec files from a directory and wait for them
+to complete in any order
+
+:doc:`Using Flux Job Status and Control API <job-status-control/README>`
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Submit job bundles and wait until all jobs complete
+
+:doc:`Use Events <synchronize-events/README>`
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Use events to synchronize compute and io-forwarding jobs running on
+separate nodes
+
+:doc:`Simple KVS Python Binding Example <kvs-python-bindings/README>`
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Use KVS Python interfaces to store user data into KVS
+
+:doc:`Job Ensemble Submitted with a New Flux Instance <job-ensemble/README>`
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Submit job bundles, print live job events, and exit when all jobs are
+complete
+
+:doc:`Hierarchical Launching <hierarchical-launching/README>`
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Launch a large number of sleep 0 jobs
+
+:doc:`Use a Flux Comms Module <comms-module/README>`
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Use a Flux Comms Module to communicate with job elements
+
+:doc:`A Data Conduit Strategy <data-conduit/README>`
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Attach to a job that receives OS time data from compute jobs
+
+.. toctree::
+   :hidden:
+
+   job-submit-cli/README
+   job-submit-api/README
+   job-submit-wait/README
+   async-bulk-job-submit/README
+   job-status-control/README
+   synchronize-events/README
+   kvs-python-bindings/README
+   job-ensemble/README
+   hierarchical-launching/README
+   comms-module/README
+   data-conduit/README

--- a/job-cancel/README.md
+++ b/job-cancel/README.md
@@ -1,6 +1,6 @@
-### Job Cancellation
+## Job Cancellation
 
-#### Description: Cancel a running job
+### Description: Cancel a running job
 
 1. Launch the submitter script:
 
@@ -21,7 +21,7 @@ First submitted job status (2241905819648) - CANCELLED
 Second submitted job status (2258951471104) - RUNNING
 ```
 
-##### Notes
+### Notes
 
 - `f = flux.Flux()` creates a new Flux handle which can be used to connect to and interact with a Flux instance.
 

--- a/job-status-control/README.md
+++ b/job-status-control/README.md
@@ -1,6 +1,6 @@
-### Using Flux Job Status and Control API
+## Using Flux Job Status and Control API
 
-#### Description: Submit job bundles and wait until all jobs complete
+### Description: Submit job bundles and wait until all jobs complete
 
 1. Allocate three nodes from a resource manager:
 
@@ -34,7 +34,7 @@ bookkeeper: all jobs completed
 
 ---
 
-##### Notes
+### Notes
 
 - `f = flux.Flux()` creates a new Flux handle which can be used to connect to and interact with a Flux instance.
 

--- a/job-submit-api/README.md
+++ b/job-submit-api/README.md
@@ -1,3 +1,5 @@
+## Job Submit API
+
 ### Part(a) - Using a direct job.submit RPC
 
 #### Description: Schedule and launch compute and io-forwarding jobs on separate nodes
@@ -80,7 +82,7 @@ JOBID    USER     NAME       ST NTASKS NNODES  RUNTIME RANKS
 
 ---
 
-##### Notes
+### Notes
 
 - `f = flux.Flux()` creates a new Flux handle which can be used to connect to and interact with a Flux instance.
 

--- a/job-submit-cli/README.md
+++ b/job-submit-cli/README.md
@@ -1,3 +1,5 @@
+# Job Submit CLI
+
 ### Part(a) - Partitioning Schedule
 
 #### Description: Launch a flux instance and schedule/launch compute and io-forwarding jobs on separate nodes

--- a/job-submit-wait/README.md
+++ b/job-submit-wait/README.md
@@ -1,3 +1,5 @@
+## Python Job Submit/Wait
+
 ### Part(a) - Python Job Submit/Wait
 
 #### Description: Submit jobs asynchronously and wait for them to complete in any order
@@ -121,7 +123,7 @@ wait: 142203682816 Success
 
 ---
 
-##### Notes
+### Notes
 
 - `h = flux.Flux()` creates a new Flux handle which can be used to connect to and interact with a Flux instance.
 

--- a/kvs-python-bindings/README.md
+++ b/kvs-python-bindings/README.md
@@ -1,6 +1,6 @@
-### KVS Python Binding Example
+## KVS Python Binding Example
 
-#### Description: Use the KVS Python interface to store user data into KVS
+### Description: Use the KVS Python interface to store user data into KVS
 
 1. Launch a Flux instance by running `flux start`, redirecting log messages to the file `out` in the current directory:
 
@@ -47,7 +47,7 @@ job.0000.0619.2300.0000
 "hello world again"
 ```
 
-##### Notes
+### Notes
 
 - `f = flux.Flux()` creates a new Flux handle which can be used to connect to and interact with a Flux instance.
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+sphinx-rtd-theme
+sphinxcontrib-spelling
+recommonmark


### PR DESCRIPTION
Adds an `index.rst` that properly links things up via ReST.  Makes the headers across the examples more uniform to improve the look of the toctree.