### PR TITLE
Globally standardize spelling of "canceled"

### DIFF
--- a/job-cancel/README.md
+++ b/job-cancel/README.md
@@ -15,9 +15,9 @@ Submitted 2nd job: 2258951471104
 First submitted job status (2241905819648) - RUNNING
 Second submitted job status (2258951471104) - PENDING
 
-Cancelled first job: 2241905819648
+Canceled first job: 2241905819648
 
-First submitted job status (2241905819648) - CANCELLED
+First submitted job status (2241905819648) - CANCELED
 Second submitted job status (2258951471104) - RUNNING
 ```
 
@@ -29,4 +29,4 @@ Second submitted job status (2258951471104) - RUNNING
 
 - `flux.job.cancel(f, jobid)` cancels the job.
 
-- `flux.job.wait_async(f, jobid)` will wait for the job to complete (or in this case, be cancelled). It returns a Flux future, which can be used to process the result later. Only jobs submitted with `waitable=True` can be waited for.
+- `flux.job.wait_async(f, jobid)` will wait for the job to complete (or in this case, be canceled). It returns a Flux future, which can be used to process the result later. Only jobs submitted with `waitable=True` can be waited for.

--- a/job-cancel/submitter.py
+++ b/job-cancel/submitter.py
@@ -42,10 +42,10 @@ print("Second submitted job status (%d) - %s\n" % (int(jobs[0].id.dec), jobs[0].
 flux.job.cancel(f, first_jobid)
 future = flux.job.wait_async(f, first_jobid).wait_for(5.0)
 return_id, success, errmsg = future.get_status()
-print("Cancelled first job: %d\n" % (int(return_id)))
+print("Canceled first job: %d\n" % (int(return_id)))
 time.sleep(1)
 
-# the second job should now run since the first was cancelled
+# the second job should now run since the first was canceled
 jobs = flux.job.JobList(f, max_entries=2).jobs()
 print("First submitted job status (%d) - %s" % (int(jobs[1].id.dec), jobs[1].status))
 print("Second submitted job status (%d) - %s" % (int(jobs[0].id.dec), jobs[0].status))


### PR DESCRIPTION
Problem: The spelling of "canceled" is inconsistently
used in flux.  Sometimes the British spelling "cancelled" is
used and othertimes the American spelling "canceled" is used.

Solution: Change all spellings of "cancelled" to "canceled".

Fixes #83