### PR TITLE
Add FluxExecutor examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,51 +1,51 @@
 **Flux Workflow Examples**
 
-**_1. [Job Submit CLI](https://github.com/flux-framework/flux-workflow-examples/tree/master/job-submit-cli)_**
+**_1. [CLI: Job Submission](https://github.com/flux-framework/flux-workflow-examples/tree/master/job-submit-cli)_**
 
 Launch a flux instance and schedule/launch compute and io-forwarding jobs on
 separate nodes using the CLI
 
-**_2. [Job Submit API](https://github.com/flux-framework/flux-workflow-examples/tree/master/job-submit-api)_**
+**_2. [Python: Job Submission](https://github.com/flux-framework/flux-workflow-examples/tree/master/job-submit-api)_**
 
 Schedule/launch compute and io-forwarding jobs on separate nodes using the Python bindings
 
-**_3. [Python Job Submit/Wait](https://github.com/flux-framework/flux-workflow-examples/tree/master/job-submit-wait)_**
+**_3. [Python: Job Submit/Wait](https://github.com/flux-framework/flux-workflow-examples/tree/master/job-submit-wait)_**
 
 Submit jobs and wait for them to complete using the Flux Python bindings
 
-**_4. [Python Asynchronous Bulk Job Submission](https://github.com/flux-framework/flux-workflow-examples/tree/master/async-bulk-job-submit)_**
+**_4. [Python: Asynchronous Bulk Job Submission](https://github.com/flux-framework/flux-workflow-examples/tree/master/async-bulk-job-submit)_**
 
 Asynchronously submit jobspec files from a directory and wait for them to complete in any order
 
-**_5. [Using Flux Job Status and Control API](https://github.com/flux-framework/flux-workflow-examples/tree/master/job-status-control)_**
+**_5. [Python: Using Flux Job Status and Control API](https://github.com/flux-framework/flux-workflow-examples/tree/master/job-status-control)_**
 
 Submit job bundles and wait until all jobs complete
 
-**_6. [Job Cancellation](https://github.com/flux-framework/flux-workflow-examples/tree/master/job-cancel)_**
+**_6. [Python: Job Cancellation](https://github.com/flux-framework/flux-workflow-examples/tree/master/job-cancel)_**
 
 Cancel a running job
 
-**_7. [Use Events](https://github.com/flux-framework/flux-workflow-examples/tree/master/synchronize-events)_**
+**_7. [Lua: Use Events](https://github.com/flux-framework/flux-workflow-examples/tree/master/synchronize-events)_**
 
 Use events to synchronize compute and io-forwarding jobs running on separate
 nodes
 
-**_8. [Simple KVS Python Binding Example](https://github.com/flux-framework/flux-workflow-examples/tree/master/kvs-python-bindings)_**
+**_8. [Python: Simple KVS Example](https://github.com/flux-framework/flux-workflow-examples/tree/master/kvs-python-bindings)_**
 
 Use KVS Python interfaces to store user data into KVS
 
-**_9. [Job Ensemble Submitted with a New Flux Instance](https://github.com/flux-framework/flux-workflow-examples/tree/master/job-ensemble)_**
+**_9. [CLI/Lua: Job Ensemble Submitted with a New Flux Instance](https://github.com/flux-framework/flux-workflow-examples/tree/master/job-ensemble)_**
 
 Submit job bundles, print live job events, and exit when all jobs are complete
 
-**_10. [Hierarchical Launching](https://github.com/flux-framework/flux-workflow-examples/tree/master/hierarchical-launching)_**
+**_10. [CLI: Hierarchical Launching](https://github.com/flux-framework/flux-workflow-examples/tree/master/hierarchical-launching)_**
 
 Launch a large number of sleep 0 jobs
 
-**_11. [Use a Flux Comms Module](https://github.com/flux-framework/flux-workflow-examples/tree/master/comms-module)_**
+**_11. [C/Lua: Use a Flux Comms Module](https://github.com/flux-framework/flux-workflow-examples/tree/master/comms-module)_**
 
 Use a Flux Comms Module to communicate with job elements
 
-**_12. [A Data Conduit Strategy](https://github.com/flux-framework/flux-workflow-examples/tree/master/data-conduit)_**
+**_12. [C/Python: A Data Conduit Strategy](https://github.com/flux-framework/flux-workflow-examples/tree/master/data-conduit)_**
 
 Attach to a job that receives OS time data from compute jobs

--- a/README.md
+++ b/README.md
@@ -17,9 +17,9 @@ Submit jobs and wait for them to complete using the Flux Python bindings
 
 Asynchronously submit jobspec files from a directory and wait for them to complete in any order
 
-**_5. [Python: Using Flux Job Status and Control API](https://github.com/flux-framework/flux-workflow-examples/tree/master/job-status-control)_**
+**_5. [Python: Tracking Job Status and Events](https://github.com/flux-framework/flux-workflow-examples/tree/master/job-status-control)_**
 
-Submit job bundles and wait until all jobs complete
+Submit job bundles, get event updates, and wait until all jobs complete
 
 **_6. [Python: Job Cancellation](https://github.com/flux-framework/flux-workflow-examples/tree/master/job-cancel)_**
 

--- a/async-bulk-job-submit/bulksubmit.py
+++ b/async-bulk-job-submit/bulksubmit.py
@@ -28,7 +28,7 @@ def progress(fraction, length=72, suffix=""):
         sys.stdout.write("\n")
 
 
-def submit_cb(f, arg):
+def submit_cb(f):
     jobs.append(job.submit_get_id(f))
 
 

--- a/async-bulk-job-submit/bulksubmit_executor.py
+++ b/async-bulk-job-submit/bulksubmit_executor.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+
+import time
+import sys
+import argparse
+import concurrent.futures as cf
+
+from flux.job import FluxExecutor, JobspecV1
+
+
+def log(label, s):
+    print(label + ": " + s)
+
+
+def progress(fraction, length=72, suffix=""):
+    fill = int(round(length * fraction))
+    bar = "\u2588" * fill + "-" * (length - fill)
+    s = f"\r|{bar}| {100 * fraction:.1f}% {suffix}"
+    sys.stdout.write(s)
+    if fraction == 1.0:
+        sys.stdout.write("\n")
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Submit a command repeatedly using FluxExecutor"
+    )
+    parser.add_argument(
+        "-n",
+        "--njobs",
+        type=int,
+        metavar="N",
+        help="Set the total number of jobs to run",
+        default=100,
+    )
+    parser.add_argument("command", nargs=argparse.REMAINDER)
+    args = parser.parse_args()
+    if not args.command:
+        args.command = ["true"]
+    t0 = time.perf_counter()
+    label = "bulksubmit_executor"
+    with FluxExecutor() as executor:
+        compute_jobspec = JobspecV1.from_command(args.command)
+        futures = [executor.submit(compute_jobspec) for _ in range(args.njobs)]
+        # wait for the jobid for each job, as a proxy for the job being submitted
+        for fut in futures:
+            fut.jobid()
+        # all jobs submitted - print timings
+        dt = time.perf_counter() - t0
+        jps = args.njobs / dt
+        log(label, f"submitted {args.njobs} jobs in {dt:.2f}s. {jps:.2f}job/s")
+        # wait for jobs to complete
+        for i, _ in enumerate(cf.as_completed(futures)):
+            if i == 0:
+                log(
+                    label,
+                    f"First job finished in about {time.perf_counter() - t0:.3f}s",
+                )
+            jps = (i + 1) / (time.perf_counter() - t0)
+            progress((i + 1) / args.njobs, length=58, suffix=f"({jps:.1f} job/s)")
+    # print time summary
+    dt = time.perf_counter() - t0
+    log(label, f"Ran {args.njobs} jobs in {dt:.1f}s. {args.njobs / dt:.1f} job/s")
+
+
+if __name__ == "__main__":
+    main()

--- a/job-status-control/bookkeeper.py
+++ b/job-status-control/bookkeeper.py
@@ -1,73 +1,51 @@
 #!/usr/bin/env python3
 
-import json
 import os
 import argparse
-import sys
 
-import flux
-from flux.job import JobspecV1
-
-compute_jobreq = JobspecV1.from_command(
-    command=["./compute.py", "10"], num_tasks=6, num_nodes=3, cores_per_task=2
-)
-compute_jobreq.cwd = os.getcwd()
-compute_jobreq.environment = dict(os.environ)
-
-io_jobreq = JobspecV1.from_command(
-    command=["./io-forwarding.py", "10"], num_tasks=3, num_nodes=3, cores_per_task=1
-)
-io_jobreq.cwd = os.getcwd()
-io_jobreq.environment = dict(os.environ)
+from flux.job import JobspecV1, FluxExecutor
 
 
-def job_state_cb(f, typemask, message, arg):
-    global njobs
-    N = njobs
-    for jobid, state, time in message.payload["transitions"]:
-        print("job " + str(jobid) + " changed its state to " + str(state))
-        if state == "INACTIVE":
-            njobs += 1
-        if njobs == N * 2:
-            f.reactor_stop(f.get_reactor())
-
-
-# submit bundles of jobs using flux.job.submit ()
-def submit_bundles(f, N):
-    for i in range(0, N // 2):
-        print(flux.job.submit(f, compute_jobreq))
-        print(flux.job.submit(f, io_jobreq))
-    if N % 2 == 1:
-        print(flux.job.submit(f, compute_jobreq))
-
-    print("bookkeeper: all jobs submitted")
+def event_callback(future, event):
+    print(f"job {future.jobid()} triggered event {event.name!r}")
 
 
 # main
 def main():
+    # set up command-line parser
     parser = argparse.ArgumentParser(
         description="submit and wait for the completion of "
         "N bundles, each consisting of compute "
         "and io-forwarding jobs"
     )
     parser.add_argument(
-        "integer",
-        metavar="N",
-        type=int,
-        help="the number of bundles to submit and wait",
+        "njobs", metavar="N", type=int, help="the number of bundles to submit and wait",
     )
-
-    if len(sys.argv) != 2:
-        njobs = 6
-    else:
-        njobs = int(sys.argv[1])
-
-    f = flux.Flux()
-    f.event_subscribe("job-state")
-    f.msg_watcher_create(job_state_cb, 0, "job-state").start()
-    submit_bundles(f, njobs)
-    print("bookkeeper: waiting until all jobs complete")
-    f.reactor_run(f.get_reactor(), 0)
+    args = parser.parse_args()
+    # set up jobspecs
+    compute_jobreq = JobspecV1.from_command(
+        command=["./compute.py", "10"], num_tasks=6, num_nodes=3, cores_per_task=2
+    )
+    compute_jobreq.cwd = os.getcwd()
+    compute_jobreq.environment = dict(os.environ)
+    io_jobreq = JobspecV1.from_command(
+        command=["./io-forwarding.py", "10"], num_tasks=3, num_nodes=3, cores_per_task=1
+    )
+    io_jobreq.cwd = os.getcwd()
+    io_jobreq.environment = dict(os.environ)
+    # submit jobs and register event callbacks for all events
+    with FluxExecutor() as executor:
+        futures = [executor.submit(compute_jobreq) for _ in range(args.njobs // 2)]
+        futures.extend(
+            executor.submit(io_jobreq) for _ in range(args.njobs // 2, args.njobs)
+        )
+        print("bookkeeper: all jobs submitted")
+        for fut in futures:
+            # each event can have a different callback
+            for event in executor.EVENTS:
+                fut.add_event_callback(event, event_callback)
+        print("bookkeeper: waiting until all jobs complete")
+    # exiting the context manager waits for the executor to complete all futures
     print("bookkeeper: all jobs completed")
 
 

--- a/job-submit-wait/README.md
+++ b/job-submit-wait/README.md
@@ -17,26 +17,26 @@
 `./submitter_wait_any.py 10`
 
 ```
-submit: 11123713638400 compute_jobspec
-submit: 11124099514368 compute_jobspec
-submit: 11124518944768 compute_jobspec
-submit: 11124921597952 compute_jobspec
-submit: 11125257142272 compute_jobspec
-submit: 11125626241024 bad_jobspec
-submit: 11126028894208 bad_jobspec
-submit: 11126347661312 bad_jobspec
-submit: 11126649651200 bad_jobspec
-submit: 11126968418304 bad_jobspec
-wait: 11123713638400 Success
-wait: 11124099514368 Success
-wait: 11124518944768 Success
-wait: 11124921597952 Success
-wait: 11125257142272 Success
-wait: 11125626241024 Error: task(s) exited with exit code 1
-wait: 11126028894208 Error: task(s) exited with exit code 1
-wait: 11126347661312 Error: task(s) exited with exit code 1
-wait: 11126649651200 Error: task(s) exited with exit code 1
-wait: 11126968418304 Error: task(s) exited with exit code 1
+submit: 46912591450240 compute_jobspec
+submit: 46912591450912 compute_jobspec
+submit: 46912591451080 compute_jobspec
+submit: 46912591363152 compute_jobspec
+submit: 46912591362984 compute_jobspec
+submit: 46912591451360 bad_jobspec
+submit: 46912591451528 bad_jobspec
+submit: 46912591451696 bad_jobspec
+submit: 46912591451864 bad_jobspec
+submit: 46912591452032 bad_jobspec
+wait: 46912591451528 Error: job returned exit code 1
+wait: 46912591451864 Error: job returned exit code 1
+wait: 46912591451360 Error: job returned exit code 1
+wait: 46912591451696 Error: job returned exit code 1
+wait: 46912591452032 Error: job returned exit code 1
+wait: 46912591450240 Success
+wait: 46912591363152 Success
+wait: 46912591450912 Success
+wait: 46912591451080 Success
+wait: 46912591362984 Success
 ```
 
 ---
@@ -99,33 +99,31 @@ wait: 6164435697664 Success
 `./submitter_wait_in_order.py 10`
 
 ```
-submit: 141868138496 compute_jobspec
-submit: 142203682816 compute_jobspec
-submit: 142639890432 compute_jobspec
-submit: 143025766400 compute_jobspec
-submit: 143344533504 compute_jobspec
-submit: 143730409472 bad_jobspec
-submit: 144233725952 bad_jobspec
-submit: 144518938624 bad_jobspec
-submit: 144871260160 bad_jobspec
-submit: 145156472832 bad_jobspec
-wait: 143730409472 Error: task(s) exited with exit code 1
-wait: 144518938624 Error: task(s) exited with exit code 1
-wait: 145156472832 Error: task(s) exited with exit code 1
-wait: 144871260160 Error: task(s) exited with exit code 1
-wait: 144233725952 Error: task(s) exited with exit code 1
-wait: 141868138496 Success
-wait: 143025766400 Success
-wait: 142639890432 Success
-wait: 143344533504 Success
-wait: 142203682816 Success
+submit: 46912593818008 compute_jobspec
+submit: 46912593818176 compute_jobspec
+submit: 46912593818344 compute_jobspec
+submit: 46912593818512 compute_jobspec
+submit: 46912593738048 compute_jobspec
+submit: 46912519873816 bad_jobspec
+submit: 46912593818792 bad_jobspec
+submit: 46912593818960 bad_jobspec
+submit: 46912593819128 bad_jobspec
+submit: 46912593819296 bad_jobspec
+wait: 46912593818008 Success
+wait: 46912593818176 Success
+wait: 46912593818344 Success
+wait: 46912593818512 Success
+wait: 46912593738048 Success
+wait: 46912519873816 Error: job returned exit code 1
+wait: 46912593818792 Error: job returned exit code 1
+wait: 46912593818960 Error: job returned exit code 1
+wait: 46912593819128 Error: job returned exit code 1
+wait: 46912593819296 Error: job returned exit code 1
 ```
 
 ---
 
 ### Notes
-
-- `h = flux.Flux()` creates a new Flux handle which can be used to connect to and interact with a Flux instance.
 
 - The following constructs a job request using the **JobspecV1** class with customizable parameters for how you want to utilize the resources allocated for your job:
 
@@ -136,6 +134,10 @@ compute_jobspec.cwd = os.getcwd()
 compute_jobspec.environment = dict(os.environ)
 ```
 
-- `flux.job.submit(h, compute_jobspec, waitable=True)` submits the job to be run, and returns a job ID once it begins running.
+- Using the executor as a context manager (`with FluxExecutor() as executor`) ensures it shuts down properly.
 
-- `result = job.wait(h, jobid)` waits for a job to transition to the **INACTIVE** state, then returns a summary of the job result, either a **Success** or an **Error** string.
+- `executor.submit(jobspec)` returns a future which completes when the job is done.
+
+- `future.exception()` blocks until the future is complete and returns (not raises) an exception if the job was canceled or was otherwise prevented from execution. Otherwise the method returns ``None``.
+
+- `future.result()` blocks until the future is complete and returns the return code of the job. If the job succeeded, the return code will be 0.

--- a/job-submit-wait/compute.py
+++ b/job-submit-wait/compute.py
@@ -13,5 +13,5 @@ parser.add_argument(
 
 args = parser.parse_args()
 
-print ("Will compute for " + str(args.integer) + " seconds.")
+print("Will compute for " + str(args.integer) + " seconds.")
 time.sleep(args.integer)

--- a/job-submit-wait/submitter_sliding_window.py
+++ b/job-submit-wait/submitter_sliding_window.py
@@ -1,46 +1,54 @@
 #!/usr/bin/env python3
 
-import flux
-import sys
 import os
+import argparse
+import collections
+import concurrent.futures as cf
 
-from flux import job
-from flux.job import JobspecV1
+from flux.job import JobspecV1, FluxExecutor
 
-njobs = 10
-window_size = 2
-if len(sys.argv) >= 2:
-    njobs = int(sys.argv[1])
-if len(sys.argv) == 3:
-    window_size = int(sys.argv[2])
 
-# open connection to broker
-h = flux.Flux()
+def main():
+    # parse command line
+    parser = argparse.ArgumentParser()
+    parser.add_argument("njobs", nargs="?", type=int, default=10)
+    parser.add_argument("window_size", nargs="?", type=int, default=2)
+    args = parser.parse_args()
+    print(args)
+    # create jobspec for compute.py
+    compute_jobspec = JobspecV1.from_command(
+        command=["./compute.py", "5"], num_tasks=4, num_nodes=2, cores_per_task=2
+    )
+    compute_jobspec.cwd = os.getcwd()
+    compute_jobspec.environment = dict(os.environ)
+    # create a queue of the jobspecs to submit
+    jobspec_queue = collections.deque(compute_jobspec for _ in range(args.njobs))
+    futures = []  # holds incomplete futures
+    with FluxExecutor() as executor:
+        while jobspec_queue or futures:
+            if len(futures) < args.window_size and jobspec_queue:
+                fut = executor.submit(jobspec_queue.popleft())
+                print(f"submit: {id(fut)}")
+                futures.append(fut)
+            else:
+                done, not_done = cf.wait(futures, return_when=cf.FIRST_COMPLETED)
+                futures = list(not_done)
+                for fut in done:
+                    if fut.exception() is not None:
+                        print(
+                            f"wait: {id(fut)} Error: job raised error "
+                            f"{fut.exception()}"
+                        )
+                    elif fut.result() == 0:
+                        print(f"wait: {id(fut)} Success")
+                    else:
+                        print(
+                            f"wait: {id(fut)} Error: job returned "
+                            f"exit code {fut.result()}"
+                        )
 
-# create jobspec for compute.py
-compute_jobspec = JobspecV1.from_command(
-    command=["./compute.py", "5"], num_tasks=4, num_nodes=2, cores_per_task=2
-)
-compute_jobspec.cwd = os.getcwd()
-compute_jobspec.environment = dict(os.environ)
 
-done = 0
-running = 0
-
-# submit jobs, keep [window_size] jobs running
-while done < njobs:
-    if running < window_size and done + running < njobs:
-        jobid = flux.job.submit(h, compute_jobspec, waitable=True)
-        print("submit: {}".format(jobid))
-        running += 1
-
-    if running == window_size or done + running == njobs:
-        jobid, success, errstr = job.wait(h)
-        if success:
-            print("wait: {} Success".format(jobid))
-        else:
-            print("wait: {} Error: {}".format(jobid, errstr))
-        done += 1
-        running -= 1
+if __name__ == "__main__":
+    main()
 
 # vim: tabstop=4 shiftwidth=4 expandtab

--- a/job-submit-wait/submitter_wait_any.py
+++ b/job-submit-wait/submitter_wait_any.py
@@ -1,49 +1,45 @@
 #!/usr/bin/env python3
 
-import json
 import os
-import sys
-import flux
+import argparse
+import concurrent.futures
 
-from flux import job
-from flux.job import JobspecV1
+from flux.job import JobspecV1, FluxExecutor
 
-if len(sys.argv) != 2:
-    njobs = 10
-else:
-    njobs = int(sys.argv[1])
 
-# open connection to broker
-h = flux.Flux()
+def main():
+    # parse command line
+    parser = argparse.ArgumentParser()
+    parser.add_argument("njobs", nargs="?", type=int, default=10)
+    args = parser.parse_args()
+    # create jobspec for compute.py
+    compute_jobspec = JobspecV1.from_command(
+        command=["./compute.py", "10"], num_tasks=4, num_nodes=2, cores_per_task=2
+    )
+    compute_jobspec.cwd = os.getcwd()
+    compute_jobspec.environment = dict(os.environ)
+    # create bad jobspec that will fail
+    bad_jobspec = JobspecV1.from_command(["/bin/false"])
+    # create an executor to submit jobs
+    with FluxExecutor() as executor:
+        futures = []
+        # submit half successful jobs and half failures
+        for _ in range(args.njobs // 2):
+            futures.append(executor.submit(compute_jobspec))
+            print(f"submit: {id(futures[-1])} compute_jobspec")
+        for _ in range(args.njobs // 2, args.njobs):
+            futures.append(executor.submit(bad_jobspec))
+            print(f"submit: {id(futures[-1])} bad_jobspec")
+        for fut in concurrent.futures.as_completed(futures):
+            if fut.exception() is not None:
+                print(f"wait: {id(fut)} Error: job raised error {fut.exception()}")
+            elif fut.result() == 0:
+                print(f"wait: {id(fut)} Success")
+            else:
+                print(f"wait: {id(fut)} Error: job returned exit code {fut.result()}")
 
-# create jobspec for compute.py
-compute_jobspec = JobspecV1.from_command(
-    command=["./compute.py", "10"], num_tasks=4, num_nodes=2, cores_per_task=2
-)
-compute_jobspec.cwd = os.getcwd()
-compute_jobspec.environment = dict(os.environ)
 
-# create bad jobspec that will fail
-bad_jobspec = JobspecV1.from_command(["/bin/false"])
-
-jobs = []
-
-# submit jobs
-for i in range(njobs):
-    if i < njobs / 2:
-        jobid = flux.job.submit(h, compute_jobspec, waitable=True)
-        print("submit: {} compute_jobspec".format(jobid))
-    else:
-        jobid = flux.job.submit(h, bad_jobspec, waitable=True)
-        print("submit: {} bad_jobspec".format(jobid))
-    jobs.append(jobid)
-
-# wait for each job to complete
-for jobid in jobs:
-    result = job.wait(h)
-    if result.success:
-        print("wait: {} Success".format(result.jobid))
-    else:
-        print("wait: {} Error: {}".format(result.jobid, result.errstr))
+if __name__ == "__main__":
+    main()
 
 # vim: tabstop=4 shiftwidth=4 expandtab

--- a/job-submit-wait/submitter_wait_in_order.py
+++ b/job-submit-wait/submitter_wait_in_order.py
@@ -1,48 +1,44 @@
 #!/usr/bin/env python3
 
-import flux
-import sys
+import argparse
 import os
 
-from flux import job
-from flux.job import JobspecV1
+from flux.job import JobspecV1, FluxExecutor
 
-if len(sys.argv) != 2:
-    njobs = 10
-else:
-    njobs = int(sys.argv[1])
 
-# open connection to broker
-h = flux.Flux()
+def main():
+    # parse command line
+    parser = argparse.ArgumentParser()
+    parser.add_argument("njobs", nargs="?", type=int, default=10)
+    args = parser.parse_args()
+    # create jobspec for compute.py
+    compute_jobspec = JobspecV1.from_command(
+        command=["./compute.py", "10"], num_tasks=4, num_nodes=2, cores_per_task=2
+    )
+    compute_jobspec.cwd = os.getcwd()
+    compute_jobspec.environment = dict(os.environ)
+    bad_jobspec = JobspecV1.from_command(["/bin/false"])
+    # create an executor to submit jobs
+    with FluxExecutor() as executor:
+        futures = []
+        # submit half successful jobs and half failures
+        for _ in range(args.njobs // 2):
+            futures.append(executor.submit(compute_jobspec))
+            print(f"submit: {id(futures[-1])} compute_jobspec")
+        for _ in range(args.njobs // 2, args.njobs):
+            futures.append(executor.submit(bad_jobspec))
+            print(f"submit: {id(futures[-1])} bad_jobspec")
+        # wait for each future in turn
+        for fut in futures:
+            if fut.exception() is not None:
+                print(f"wait: {id(fut)} Error: job raised error {fut.exception()}")
+            elif fut.result() == 0:
+                print(f"wait: {id(fut)} Success")
+            else:
+                print(f"wait: {id(fut)} Error: job returned exit code {fut.result()}")
 
-# create jobspec for compute.py
-compute_jobspec = JobspecV1.from_command(
-    command=["./compute.py", "10"], num_tasks=4, num_nodes=2, cores_per_task=2
-)
-compute_jobspec.cwd = os.getcwd()
-compute_jobspec.environment = dict(os.environ)
 
-# create bad jobspec that will fail
-bad_jobspec = JobspecV1.from_command(["/bin/false"])
-
-jobs = []
-
-# submit jobs
-for i in range(njobs):
-    if i < njobs / 2:
-        jobid = flux.job.submit(h, compute_jobspec, waitable=True)
-        print("submit: {} compute.py".format(jobid))
-    else:
-        jobid = job.submit(h, bad_jobspec, waitable=True)
-        print("submit: {} bad_jobspec".format(jobid))
-    jobs.append(jobid)
-
-# wait for each job in turn by jobid
-for jobid in jobs:
-    result = job.wait(h, jobid)
-    if result.success:
-        print("wait: {} Success".format(result.jobid))
-    else:
-        print("wait: {} Error: {}".format(result.jobid, result.errstr))
+if __name__ == "__main__":
+    main()
 
 # vim: tabstop=4 shiftwidth=4 expandtab


### PR DESCRIPTION
This PR adds examples of using `FluxExecutor` and  `FluxEventExecutor` flux-framework/flux-core#3468. In particular, I modify the job-submit-wait examples so that they only use `FluxExecutor`, I add an example of bulk submission with `FluxExecutor` to async-bulk-job-submit (but I leave the original example), and I modify the job-status-control example to use `FluxEventExecutor`. 

In these three cases I think the executor implementation is easier to explain; in the other Python examples I don't think the executor adds anything, so I didn't modify them.

As unrelated issues I also fix #82 and add the programming language into the title of each example in the README, since as a user the first thing I want to know is whether I will be able to understand or use the code in the examples (and I don't understand Lua very well at all).