### PR TITLE
Docs: specify how to get example source code

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,19 @@
 **Flux Workflow Examples**
 
+The examples contained here demonstrate and explain some simple use-cases with Flux,
+and make use of Flux's command-line interface (CLI), Flux's C library,
+and the Python and Lua bindings to the C library.
+
+**Requirements**
+
+The examples assume that you have installed:
+
+1. A recent version of Flux
+
+2. Python 3.6+
+
+3. Lua 5.1+
+
 **_1. [CLI: Job Submission](https://github.com/flux-framework/flux-workflow-examples/tree/master/job-submit-cli)_**
 
 Launch a flux instance and schedule/launch compute and io-forwarding jobs on

--- a/async-bulk-job-submit/README.md
+++ b/async-bulk-job-submit/README.md
@@ -1,7 +1,7 @@
 ## Python Asynchronous Bulk Job Submission
 
-Parts (a) and (b) demonstrate different implementations of the same basic use-case---
-submitting large numbers of jobs to Flux. For simplicity, in these examples all of the jobs are identical.
+Parts (a) and (b) demonstrate different implementations of the same basic use-case---submitting
+large numbers of jobs to Flux. For simplicity, in these examples all of the jobs are identical.
 
 In part (a), we use the `flux.job.submit_async` and `flux.job.wait` functions to submit jobs and wait for them.
 In part (b), we use the `FluxExecutor` class, which offers a higher-level interface. It is important to note that
@@ -9,6 +9,15 @@ these two different implementations deal with very different kinds of futures.
 The executor's futures fulfill in the background and callbacks added to the futures may
 be invoked by different threads; the `submit_async` futures do not fulfill in the background, callbacks are always
 invoked by the same thread that added them, and sharing the futures among threads is not supported.
+
+### Setup - Downloading the Files
+
+If you haven't already, download the files and change your working directory:
+
+```
+$ git clone https://github.com/flux-framework/flux-workflow-examples.git
+$ cd flux-workflow-examples/async-bulk-job-submit
+```
 
 ### Part (a) - Using `submit_async`
 

--- a/comms-module/README.md
+++ b/comms-module/README.md
@@ -2,6 +2,17 @@
 
 #### Description: Use a Flux comms module to communicate with job elements
 
+##### Setup
+
+If you haven't already, download the files and change your working directory:
+
+```
+$ git clone https://github.com/flux-framework/flux-workflow-examples.git
+$ cd flux-workflow-examples/comms-module
+```
+
+##### Execution
+
 1. `salloc -N3 -ppdebug`
 
 2. Point to `flux-core`'s `pkgconfig` directory:

--- a/data-conduit/README.md
+++ b/data-conduit/README.md
@@ -2,6 +2,17 @@
 
 ### Description: Use a data stream to send packets through
 
+#### Setup
+
+If you haven't already, download the files and change your working directory:
+
+```
+$ git clone https://github.com/flux-framework/flux-workflow-examples.git
+$ cd flux-workflow-examples/data-conduit
+```
+
+#### Execution
+
 1. Allocate three nodes from a resource manager:
 
 `salloc -N3 -ppdebug`
@@ -15,7 +26,7 @@
 
 3. `make`
 
-4. Add the directory of the modules to `FLUX_MODULE_PATH`; if the module was built in the current dir:
+4. Add the directory of the modules to `FLUX_MODULE_PATH`, if the module was built in the current directory:
 
 `export FLUX_MODULE_PATH=${FLUX_MODULE_PATH}:$(pwd)`
 

--- a/hierarchical-launching/README.md
+++ b/hierarchical-launching/README.md
@@ -2,6 +2,17 @@
 
 ### Description: Launch an ensemble of sleep 0 tasks
 
+#### Setup
+
+If you haven't already, download the files and change your working directory:
+
+```
+$ git clone https://github.com/flux-framework/flux-workflow-examples.git
+$ cd flux-workflow-examples/hierarchical-launching
+```
+
+#### Execution
+
 1. `salloc -N3 -ppdebug`
 
 2. `srun --pty --mpi=none -N3 flux start -o,-S,log-filename=out`

--- a/index.rst
+++ b/index.rst
@@ -1,67 +1,79 @@
 Flux Workflow Examples
 ----------------------
 
-:doc:`Job Submit CLI <job-submit-cli/README>`
+The examples contained here demonstrate and explain some simple use-cases with Flux,
+and make use of Flux's command-line interface (CLI), Flux's C library, and the Python and Lua bindings to the C library.
+The entire set of examples can be downloaded by cloning the `Github repo <https://github.com/flux-framework/flux-workflow-examples>`_.
+
+The examples assume that you have installed:
+
+#. A recent version of Flux
+
+#. Python 3.6+
+
+#. Lua 5.1+
+
+:doc:`CLI: Job Submission <job-submit-cli/README>`
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Launch a flux instance and schedule/launch compute and io-forwarding
 jobs on separate nodes using the CLI
 
-:doc:`Job Submit API <job-submit-api/README>`
+:doc:`Python: Job Submission <job-submit-api/README>`
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Schedule/launch compute and io-forwarding jobs on separate nodes using
 the Python bindings
 
-:doc:`Python Job Submit/Wait <job-submit-wait/README>`
+:doc:`Python: Job Submit/Wait <job-submit-wait/README>`
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Submit jobs and wait for them to complete using the Flux Python bindings
 
-:doc:`Python Asynchronous Bulk Job Submission <async-bulk-job-submit/README>`
+:doc:`Python: Asynchronous Bulk Job Submission <async-bulk-job-submit/README>`
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Asynchronously submit jobspec files from a directory and wait for them
 to complete in any order
 
-:doc:`Using Flux Job Status and Control API <job-status-control/README>`
+:doc:`Python: Tracking Job Status and Events <job-status-control/README>`
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Submit job bundles and wait until all jobs complete
 
-:doc:`Job Cancellation <job-cancel/README>`
+:doc:`Python: Job Cancellation <job-cancel/README>`
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Cancel a running job
 
-:doc:`Use Events <synchronize-events/README>`
+:doc:`Lua: Use Events <synchronize-events/README>`
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Use events to synchronize compute and io-forwarding jobs running on
 separate nodes
 
-:doc:`Simple KVS Python Binding Example <kvs-python-bindings/README>`
+:doc:`Python: Simple KVS Example <kvs-python-bindings/README>`
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Use KVS Python interfaces to store user data into KVS
 
-:doc:`Job Ensemble Submitted with a New Flux Instance <job-ensemble/README>`
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+:doc:`CLI/Lua: Job Ensemble Submitted with a New Flux Instance <job-ensemble/README>`
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Submit job bundles, print live job events, and exit when all jobs are
 complete
 
-:doc:`Hierarchical Launching <hierarchical-launching/README>`
+:doc:`CLI: Hierarchical Launching <hierarchical-launching/README>`
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Launch a large number of sleep 0 jobs
 
-:doc:`Use a Flux Comms Module <comms-module/README>`
+:doc:`C/Lua: Use a Flux Comms Module <comms-module/README>`
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Use a Flux Comms Module to communicate with job elements
 
-:doc:`A Data Conduit Strategy <data-conduit/README>`
+:doc:`C/Python: A Data Conduit Strategy <data-conduit/README>`
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Attach to a job that receives OS time data from compute jobs

--- a/job-cancel/README.md
+++ b/job-cancel/README.md
@@ -2,6 +2,17 @@
 
 ### Description: Cancel a running job
 
+#### Setup
+
+If you haven't already, download the files and change your working directory:
+
+```
+$ git clone https://github.com/flux-framework/flux-workflow-examples.git
+$ cd flux-workflow-examples/job-cancel
+```
+
+#### Execution
+
 1. Launch the submitter script:
 
 `./submitter.py $(flux resource list -no {ncores} --state=up)`

--- a/job-ensemble/README.md
+++ b/job-ensemble/README.md
@@ -2,6 +2,17 @@
 
 #### Description: Launch a flux instance and submit one instance of an io-forwarding job and 50 compute jobs, each spanning the entire set of nodes.
 
+#### Setup
+
+If you haven't already, download the files and change your working directory:
+
+```
+$ git clone https://github.com/flux-framework/flux-workflow-examples.git
+$ cd flux-workflow-examples/job-ensemble
+```
+
+#### Execution
+
 1. `salloc -N3 -ppdebug`
 
 2. `cat ensemble.sh`

--- a/job-status-control/README.md
+++ b/job-status-control/README.md
@@ -2,6 +2,17 @@
 
 ### Description: Submit job bundles, get event updates, and wait until all jobs complete
 
+#### Setup
+
+If you haven't already, download the files and change your working directory:
+
+```
+$ git clone https://github.com/flux-framework/flux-workflow-examples.git
+$ cd flux-workflow-examples/job-status-control
+```
+
+#### Execution
+
 1. Allocate three nodes from a resource manager:
 
 `salloc -N3 -p pdebug`

--- a/job-submit-api/README.md
+++ b/job-submit-api/README.md
@@ -1,5 +1,12 @@
 ## Job Submit API
 
+To run the following examples, download the files and change your working directory:
+
+```
+$ git clone https://github.com/flux-framework/flux-workflow-examples.git
+$ cd flux-workflow-examples/job-submit-api
+```
+
 ### Part(a) - Using a direct job.submit RPC
 
 #### Description: Schedule and launch compute and io-forwarding jobs on separate nodes

--- a/job-submit-cli/README.md
+++ b/job-submit-cli/README.md
@@ -1,4 +1,11 @@
-# Job Submit CLI
+## Job Submit CLI
+
+To run the following examples, download the files and change your working directory:
+
+```
+$ git clone https://github.com/flux-framework/flux-workflow-examples.git
+$ cd flux-workflow-examples/job-submit-cli
+```
 
 ### Part(a) - Partitioning Schedule
 

--- a/job-submit-wait/README.md
+++ b/job-submit-wait/README.md
@@ -1,5 +1,12 @@
 ## Python Job Submit/Wait
 
+To run the following examples, download the files and change your working directory:
+
+```
+$ git clone https://github.com/flux-framework/flux-workflow-examples.git
+$ cd flux-workflow-examples/job-submit-wait
+```
+
 ### Part(a) - Python Job Submit/Wait
 
 #### Description: Submit jobs asynchronously and wait for them to complete in any order

--- a/kvs-python-bindings/README.md
+++ b/kvs-python-bindings/README.md
@@ -2,6 +2,13 @@
 
 ### Description: Use the KVS Python interface to store user data into KVS
 
+If you haven't already, download the files and change your working directory:
+
+```
+$ git clone https://github.com/flux-framework/flux-workflow-examples.git
+$ cd flux-workflow-examples/kvs-python-bindings
+```
+
 1. Launch a Flux instance by running `flux start`, redirecting log messages to the file `out` in the current directory:
 
 `flux start -s 1 -o,-S,log-filename=out`

--- a/synchronize-events/README.md
+++ b/synchronize-events/README.md
@@ -2,6 +2,13 @@
 
 #### Description: Using events to synchronize compute and io-forwarding jobs running on separate nodes
 
+If you haven't already, download the files and change your working directory:
+
+```
+$ git clone https://github.com/flux-framework/flux-workflow-examples.git
+$ cd flux-workflow-examples/synchronize-events
+```
+
 1. `salloc -N3 -ppdebug`
 
 2. `srun --pty --mpi=none -N3 flux start -o,-S,log-filename=out`


### PR DESCRIPTION
Adds some additional directions to the READMEs and the sphinx documentation, specifying that to run the examples you have to clone the repo. Adding links to the source code would also work, but I think cloning the repo and changing your working directory is a lot easier than copying each file one by one.