### PR TITLE
[WIP] new example: event watch/wait

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,3 +63,7 @@ Use a Flux Comms Module to communicate with job elements
 **_12. [C/Python: A Data Conduit Strategy](https://github.com/flux-framework/flux-workflow-examples/tree/master/data-conduit)_**
 
 Attach to a job that receives OS time data from compute jobs
+
+**_13. [Python: Job Event Watch/Wait](https://github.com/flux-framework/flux-workflow-examples/tree/master/event-watch-wait)_**
+
+Use the Python bindings to wait on and watch for job events

--- a/event-watch-wait/README.md
+++ b/event-watch-wait/README.md
@@ -1,0 +1,61 @@
+## Job Event Watch/Wait
+
+To run the following examples, download the files and change your working directory:
+
+```
+$ git clone https://github.com/flux-framework/flux-workflow-examples.git
+$ cd flux-workflow-examples/job-event
+```
+
+### Part(a) - Event Wait
+
+#### Description: Use the job eventlog to wait for a certain event synchronously.
+
+1. `salloc -N3 -ppdebug`
+
+2. `srun --pty --mpi=none -N3 flux start -o,-S,log-filename=out`
+
+3. `flux python event-wait.py $(flux mini submit -n4 hostname)`
+
+```
+node24
+node24
+node24
+node24
+```
+
+### Part(b) - Event Watch
+
+#### Description: Asynchronously watch job events via a `.then()` callback.
+
+1. `salloc -N3 -ppdebug`
+
+2. `srun --pty --mpi=none -N3 flux start -o,-S,log-filename=out`
+
+3. `flux python event-watch.py $(flux mini submit -n4 sleep 1)`
+
+```
+1616789213.11403: submit {'userid': 58985, 'urgency': 16, 'flags': 0}
+1616789213.12785: depend {}
+1616789213.12789: priority {'priority': 16}
+1616789213.13040: alloc {'annotations': {'sched': {'resource_summary': 'rank0/core[0-3]'}}}
+1616789213.13865: start {}
+1616789213.13138: init {}
+1616789213.13288: starting {}
+1616789213.18925: shell.init {'leader-rank': 0, 'size': 1, 'service': '58985-shell-4548605247488'}
+1616789213.20083: shell.start {'task-count': 4}
+1616789214.20549: complete {'status': 0}
+1616789214.20554: done {}
+1616789214.20569: finish {'status': 0}
+1616789214.20904: release {'ranks': 'all', 'final': True}
+1616789214.21015: free {}
+1616789214.21027: clean {}
+```
+
+---
+
+### Notes
+
+- `job.event_wait(h, jobid, name, eventlog="eventlog")` waits for an event named `name` in `eventlog` synchronously. It blocks and returns an `EventLogEvent` for the matched event, or `None` if the eventlog ended with no match.
+
+- `job.event_watch_async(h, jobid, name="*", eventlog="eventlog")` returns a `JobEventWatchFuture` which can be used to asynchronously watch job events via a `.then()` callback. Events can be optionally filtered on the `name` glob (default all events). A `JobEventWatchFuture` internally queues events for consumption in the continuation with `future.get_event()`. `future.reset()` must be called to "consume" the event.

--- a/event-watch-wait/event-wait.py
+++ b/event-watch-wait/event-wait.py
@@ -1,0 +1,19 @@
+import sys
+import flux
+from flux import job
+from flux.job import JobID
+
+jobid = JobID(sys.argv[1]).dec
+
+h = flux.Flux()
+
+# block until "start" event, so we know exec.eventlog is available
+job.event_wait(h, jobid, "start")
+
+# block until "shell.init" event, so we know output eventlog is available
+job.event_wait(h, jobid, "shell.init", eventlog="guest.exec.eventlog")
+
+# process output eventlog (doesn't differentiate between stdout/err)
+for event in job.event_watch(h, jobid, eventlog="guest.output"):
+    if event.name == "data" and "data" in event.context:
+        print(event.context["data"].strip())

--- a/event-watch-wait/event-watch.py
+++ b/event-watch-wait/event-watch.py
@@ -1,0 +1,21 @@
+import sys
+import flux
+from flux import job
+from flux.job import JobID
+
+jobid = JobID(sys.argv[1]).dec
+
+
+def cb(future, h):
+    event = future.get_event()
+    if event is None:
+        return
+    if event.name == "start":
+        job.event_watch_async(h, jobid, eventlog="guest.exec.eventlog").then(cb, h)
+    print(event)
+    future.reset()
+
+
+h = flux.Flux()
+job.event_watch_async(h, jobid).then(cb, h)
+h.reactor_run()


### PR DESCRIPTION
This is a [WIP] PR that adds an event watch and an event wait example to the workflow examples repository. I simply took the examples from https://github.com/flux-framework/flux-core/pull/2986#issuecomment-645659090 and put them under a new directory called `event-watch-wait/`. 

I'm leaving this as [WIP] because I'm not sure if the Python scripts in their current state are good to go as standalone examples. Apologies that I don't know enough about the context of event watching/waiting, so any feedback or suggestions on additions to this example is greatly appreciated. 😅

Fixes #69